### PR TITLE
Feature/refactoring 20250608

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
@@ -64,9 +64,6 @@ namespace Styly.XRRig
 
             return interactableGameObjects.ToArray();
         }
-
-
-
 #endif
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+#if UNITY_VISIONOS && USE_POLYSPATIAL
 using Unity.PolySpatial;
+#endif
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit.Interactables;
 
@@ -10,6 +12,7 @@ namespace Styly.XRRig
     /// </summary>
     public class AddVisionOSHoverEffect : MonoBehaviour
     {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
         void Start()
         {
             if (Utils.IsVisionOS())
@@ -64,5 +67,6 @@ namespace Styly.XRRig
 
 
 
+#endif
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -24,16 +24,8 @@ namespace Styly.XRRig
         // Parameters of Bounded Guide Frame Gizmo
         private Vector3 DefaultBoundedGuideFrameGizmoSize = new(1, 1, 1);
         private Color BoundedGuideFrameGizmoColor = Color.yellow;
-
-        // Start is called before the first frame update
-        void Awake()
-        {
-            // Set volume camera configuration
-            SetVolumeCameraConfiguration();
-            // Set the position of volume camera to (0,0,0) when Bounded mode
-            SetBoundedVolumeCameraPositionToZero();
-        }
-
+        
+        
         /// <summary>
         /// Set volume camera configuration to VolumeCamera
         /// </summary>
@@ -49,7 +41,7 @@ namespace Styly.XRRig
                 volumeCamera.WindowConfiguration = UnBoundedVolumeCamera;
             }
         }
-        
+
         /// <summary>
         /// Set the position of the Bounded volume camera to (0,0,0).
         /// </summary>
@@ -60,7 +52,7 @@ namespace Styly.XRRig
                 Debug.Log("Set Bounded Volume Camera Position to (0,0,0)");
             }
         }
-
+        
 #if UNITY_EDITOR
         /// <summary>
         /// When UseBoundedModeForVisionOs is changed in the editor, update some configurations.
@@ -113,7 +105,23 @@ namespace Styly.XRRig
                 Gizmos.DrawWireCube(new Vector3(0,0,0), DefaultBoundedGuideFrameGizmoSize);
             }
         }
+
 #endif
 #endif
+        private void AwakeForVisionOS()
+        {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
+            // Set volume camera configuration
+            SetVolumeCameraConfiguration();
+            // Set the position of volume camera to (0,0,0) when Bounded mode
+            SetBoundedVolumeCameraPositionToZero();
+#endif
+        }
+        
+        // Start is called before the first frame update
+        void Awake()
+        {
+            AwakeForVisionOS();
+        }
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -1,10 +1,13 @@
 using UnityEngine;
+#if UNITY_VISIONOS && USE_POLYSPATIAL
 using Unity.PolySpatial;
+#endif
 
 namespace Styly.XRRig
 {
     public class StylyXrRig : MonoBehaviour
     {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
         [SerializeField]
         private bool UseBoundedModeForVisionOs = false;
         [SerializeField]
@@ -110,6 +113,7 @@ namespace Styly.XRRig
                 Gizmos.DrawWireCube(new Vector3(0,0,0), DefaultBoundedGuideFrameGizmoSize);
             }
         }
-# endif
+#endif
+#endif
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
+++ b/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
@@ -15,6 +15,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.polyspatial.visionos",
+            "expression": "",
+            "define": "USE_POLYSPATIAL"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/com.styly.styly-xr-rig/package.json
+++ b/Packages/com.styly.styly-xr-rig/package.json
@@ -12,10 +12,6 @@
   "dependencies": {
     "com.unity.xr.interaction.toolkit": "3.0.8",
     "com.unity.xr.hands": "1.5.0",
-    "com.unity.polyspatial": "2.2.4",
-    "com.unity.polyspatial.visionos": "2.2.4",
-    "com.unity.polyspatial.xr": "2.2.4",
-    "com.unity.xr.visionos": "2.2.4",
     "com.unity.xr.arfoundation": "6.0.3",
     "com.unity.visualscripting": "1.9.6",
     "com.unity.xr.management": "4.5.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,10 +7,6 @@
       "dependencies": {
         "com.unity.xr.interaction.toolkit": "3.0.8",
         "com.unity.xr.hands": "1.5.0",
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.polyspatial.visionos": "2.2.4",
-        "com.unity.polyspatial.xr": "2.2.4",
-        "com.unity.xr.visionos": "2.2.4",
         "com.unity.xr.arfoundation": "6.0.3",
         "com.unity.visualscripting": "1.9.6",
         "com.unity.xr.management": "4.5.1",
@@ -49,13 +45,6 @@
     },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.ext.flatsharp": {
-      "version": "1.1.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -114,58 +103,6 @@
       "depth": 3,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.nuget.newtonsoft-json": {
-      "version": "3.2.1",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "2.0.0",
-        "com.unity.collections": "2.4.3",
-        "com.unity.inputsystem": "1.10.0",
-        "com.unity.shadergraph": "17.0.3",
-        "com.unity.textmeshpro": "3.0.7",
-        "com.unity.ext.flatsharp": "1.1.1",
-        "com.unity.modules.video": "1.0.0",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.nuget.newtonsoft-json": "3.2.1",
-        "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial.visionos": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.xr.visionos": "2.2.4",
-        "com.unity.xr.management": "4.5.0",
-        "com.unity.polyspatial.xr": "2.2.4"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial.xr": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.xr.hands": "1.4.1",
-        "com.unity.inputsystem": "1.10.0",
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.textmeshpro": "3.0.7",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.xr.arfoundation": "6.0.3",
-        "com.unity.nuget.newtonsoft-json": "3.2.1"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
@@ -262,14 +199,6 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
-    },
-    "com.unity.textmeshpro": {
-      "version": "5.0.0",
-      "depth": 2,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.ugui": "2.0.0"
-      }
     },
     "com.unity.timeline": {
       "version": "1.8.7",


### PR DESCRIPTION
Remove polyspatial from devendencies

This pull request introduces changes to enhance compatibility with VisionOS by adding conditional compilation directives and removing unused dependencies. The most significant updates include the addition of VisionOS-specific logic, cleanup of package dependencies, and updates to assembly definitions.

### VisionOS compatibility enhancements:
* [`Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs`](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR2-R4): Added conditional compilation (`#if UNITY_VISIONOS && USE_POLYSPATIAL`) to include VisionOS-specific logic in the `Start` method and `GetInteractableGameObjects()` method. [[1]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR2-R4) [[2]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR15) [[3]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aL64-R67)
* [`Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs`](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R2-R10): Added VisionOS-specific fields and refactored the `Awake` method to call a new `AwakeForVisionOS` helper method under conditional compilation. [[1]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R2-R10) [[2]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51L25-L32) [[3]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R108-R125)

### Dependency cleanup:
* [`Packages/com.styly.styly-xr-rig/package.json`](diffhunk://#diff-8813a66c25c18246e16b8e32bdfb2202c1e48054a6a10fbaa397fc72d4982343L15-L18): Removed dependencies related to PolySpatial and VisionOS that are no longer required.
* [`Packages/packages-lock.json`](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL10-L13): Removed unused packages, including `com.unity.polyspatial`, `com.unity.polyspatial.visionos`, `com.unity.polyspatial.xr`, and their subdependencies such as `com.unity.nuget.newtonsoft-json` and `com.unity.textmeshpro`. [[1]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL10-L13) [[2]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL57-L63) [[3]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL119-L170) [[4]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL266-L273)

### Assembly definition updates:
* [`Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef`](diffhunk://#diff-836aaa52f4e4c9d557e819f7f408d4033188ad52b838f5736b1481da4daf761eL18-R24): Added a new `versionDefines` entry for `com.unity.polyspatial.visionos` with the `USE_POLYSPATIAL` define constraint.