### PR TITLE
Update dependencies

### DIFF
--- a/Packages/com.styly.styly-xr-rig/package.json
+++ b/Packages/com.styly.styly-xr-rig/package.json
@@ -11,12 +11,11 @@
   },
   "dependencies": {
     "com.unity.xr.interaction.toolkit": "3.0.8",
-    "com.unity.xr.hands": "1.5.0",
-    "com.unity.xr.arfoundation": "6.0.3",
+    "com.unity.xr.hands": "1.5.1",
+    "com.unity.xr.arfoundation": "6.1.0",
     "com.unity.visualscripting": "1.9.6",
     "com.unity.xr.management": "4.5.1",
-    "com.unity.xr.openxr": "1.14.0",
-    "com.unity.xr.meta-openxr": "1.14.0"
+    "com.unity.xr.openxr": "1.8.2"
   },
   "samples": []
 }


### PR DESCRIPTION
This pull request updates the dependencies in the `package.json` file for the `STYLY XR Rig` package to ensure compatibility with newer versions and remove unused packages.

### Dependency Updates:
* Updated `com.unity.xr.hands` from version `1.5.0` to `1.5.1`.
* Updated `com.unity.xr.arfoundation` from version `6.0.3` to `6.1.0`.

### Dependency Removal:
* Removed `com.unity.xr.meta-openxr` (previously version `1.14.0`).

### Downgrade:
* Downgraded `com.unity.xr.openxr` from version `1.14.0` to `1.8.2`.

Close #48 