### PR TITLE
Merge from develop

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+#if UNITY_VISIONOS && USE_POLYSPATIAL
 using Unity.PolySpatial;
+#endif
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit.Interactables;
 
@@ -10,6 +12,7 @@ namespace Styly.XRRig
     /// </summary>
     public class AddVisionOSHoverEffect : MonoBehaviour
     {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
         void Start()
         {
             if (Utils.IsVisionOS())
@@ -61,8 +64,6 @@ namespace Styly.XRRig
 
             return interactableGameObjects.ToArray();
         }
-
-
-
+#endif
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs
@@ -12,14 +12,17 @@ namespace Styly.XRRig
     /// </summary>
     public class AddVisionOSHoverEffect : MonoBehaviour
     {
-#if UNITY_VISIONOS && USE_POLYSPATIAL
         void Start()
         {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
             if (Utils.IsVisionOS())
             {
                 AttachHoverEffectToInteractableGameObjects();
             }
+#endif
         }
+
+#if UNITY_VISIONOS && USE_POLYSPATIAL
 
         /// <summary>
         /// Attach VisionOSHoverEffect to the interactable GameObjects

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -1,10 +1,13 @@
 using UnityEngine;
+#if UNITY_VISIONOS && USE_POLYSPATIAL
 using Unity.PolySpatial;
+#endif
 
 namespace Styly.XRRig
 {
     public class StylyXrRig : MonoBehaviour
     {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
         [SerializeField]
         private bool UseBoundedModeForVisionOs = false;
         [SerializeField]
@@ -21,16 +24,8 @@ namespace Styly.XRRig
         // Parameters of Bounded Guide Frame Gizmo
         private Vector3 DefaultBoundedGuideFrameGizmoSize = new(1, 1, 1);
         private Color BoundedGuideFrameGizmoColor = Color.yellow;
-
-        // Start is called before the first frame update
-        void Awake()
-        {
-            // Set volume camera configuration
-            SetVolumeCameraConfiguration();
-            // Set the position of volume camera to (0,0,0) when Bounded mode
-            SetBoundedVolumeCameraPositionToZero();
-        }
-
+        
+        
         /// <summary>
         /// Set volume camera configuration to VolumeCamera
         /// </summary>
@@ -46,7 +41,7 @@ namespace Styly.XRRig
                 volumeCamera.WindowConfiguration = UnBoundedVolumeCamera;
             }
         }
-        
+
         /// <summary>
         /// Set the position of the Bounded volume camera to (0,0,0).
         /// </summary>
@@ -57,7 +52,7 @@ namespace Styly.XRRig
                 Debug.Log("Set Bounded Volume Camera Position to (0,0,0)");
             }
         }
-
+        
 #if UNITY_EDITOR
         /// <summary>
         /// When UseBoundedModeForVisionOs is changed in the editor, update some configurations.
@@ -110,6 +105,23 @@ namespace Styly.XRRig
                 Gizmos.DrawWireCube(new Vector3(0,0,0), DefaultBoundedGuideFrameGizmoSize);
             }
         }
-# endif
+
+#endif
+#endif
+        private void AwakeForVisionOS()
+        {
+#if UNITY_VISIONOS && USE_POLYSPATIAL
+            // Set volume camera configuration
+            SetVolumeCameraConfiguration();
+            // Set the position of volume camera to (0,0,0) when Bounded mode
+            SetBoundedVolumeCameraPositionToZero();
+#endif
+        }
+        
+        // Start is called before the first frame update
+        void Awake()
+        {
+            AwakeForVisionOS();
+        }
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
+++ b/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
@@ -15,6 +15,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.polyspatial.visionos",
+            "expression": "",
+            "define": "USE_POLYSPATIAL"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/com.styly.styly-xr-rig/package.json
+++ b/Packages/com.styly.styly-xr-rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.styly.styly-xr-rig",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "displayName": "STYLY XR Rig",
   "unity": "6000.0",
   "description": "STYLY XR Rig",

--- a/Packages/com.styly.styly-xr-rig/package.json
+++ b/Packages/com.styly.styly-xr-rig/package.json
@@ -12,10 +12,6 @@
   "dependencies": {
     "com.unity.xr.interaction.toolkit": "3.0.8",
     "com.unity.xr.hands": "1.5.0",
-    "com.unity.polyspatial": "2.2.4",
-    "com.unity.polyspatial.visionos": "2.2.4",
-    "com.unity.polyspatial.xr": "2.2.4",
-    "com.unity.xr.visionos": "2.2.4",
     "com.unity.xr.arfoundation": "6.0.3",
     "com.unity.visualscripting": "1.9.6",
     "com.unity.xr.management": "4.5.1",

--- a/Packages/com.styly.styly-xr-rig/package.json
+++ b/Packages/com.styly.styly-xr-rig/package.json
@@ -11,12 +11,10 @@
   },
   "dependencies": {
     "com.unity.xr.interaction.toolkit": "3.0.8",
-    "com.unity.xr.hands": "1.5.0",
-    "com.unity.xr.arfoundation": "6.0.3",
+    "com.unity.xr.hands": "1.5.1",
+    "com.unity.xr.arfoundation": "6.1.0",
     "com.unity.visualscripting": "1.9.6",
-    "com.unity.xr.management": "4.5.1",
-    "com.unity.xr.openxr": "1.14.0",
-    "com.unity.xr.meta-openxr": "1.14.0"
+    "com.unity.xr.management": "4.5.1"
   },
   "samples": []
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,8 +10,6 @@
     "com.unity.toolchain.macos-arm64-linux-x86_64": "2.0.4",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.6",
-    "com.unity.xr.meta-openxr": "2.0.1",
-    "com.unity.xr.openxr": "1.14.0",
     "com.unity.xr.visionos": "2.2.4",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -6,12 +6,10 @@
       "source": "embedded",
       "dependencies": {
         "com.unity.xr.interaction.toolkit": "3.0.8",
-        "com.unity.xr.hands": "1.5.0",
-        "com.unity.xr.arfoundation": "6.0.3",
+        "com.unity.xr.hands": "1.5.1",
+        "com.unity.xr.arfoundation": "6.1.0",
         "com.unity.visualscripting": "1.9.6",
-        "com.unity.xr.management": "4.5.1",
-        "com.unity.xr.openxr": "1.14.0",
-        "com.unity.xr.meta-openxr": "1.14.0"
+        "com.unity.xr.management": "4.5.1"
       }
     },
     "com.unity.burst": {
@@ -76,7 +74,7 @@
     },
     "com.unity.inputsystem": {
       "version": "1.14.0",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.uielements": "1.0.0"
@@ -242,7 +240,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.arfoundation": {
-      "version": "6.0.5",
+      "version": "6.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -250,7 +248,7 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.inputsystem": "1.6.3",
         "com.unity.mathematics": "1.2.6",
-        "com.unity.xr.core-utils": "2.3.0",
+        "com.unity.xr.core-utils": "2.5.1",
         "com.unity.xr.management": "4.4.0",
         "com.unity.editorcoroutines": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0",
@@ -269,7 +267,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.hands": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -299,7 +297,7 @@
     },
     "com.unity.xr.legacyinputhelpers": {
       "version": "2.1.12",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.modules.vr": "1.0.0",
@@ -317,30 +315,6 @@
         "com.unity.xr.core-utils": "2.2.1",
         "com.unity.modules.subsystems": "1.0.0",
         "com.unity.xr.legacyinputhelpers": "2.1.11"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.xr.meta-openxr": {
-      "version": "2.0.1",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.xr.openxr": "1.10.0",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.xr.management": "4.4.0",
-        "com.unity.xr.arfoundation": "6.0.1"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.xr.openxr": {
-      "version": "1.14.0",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.inputsystem": "1.6.3",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.xr.management": "4.4.0",
-        "com.unity.xr.legacyinputhelpers": "2.1.2"
       },
       "url": "https://packages.unity.com"
     },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,10 +7,6 @@
       "dependencies": {
         "com.unity.xr.interaction.toolkit": "3.0.8",
         "com.unity.xr.hands": "1.5.0",
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.polyspatial.visionos": "2.2.4",
-        "com.unity.polyspatial.xr": "2.2.4",
-        "com.unity.xr.visionos": "2.2.4",
         "com.unity.xr.arfoundation": "6.0.3",
         "com.unity.visualscripting": "1.9.6",
         "com.unity.xr.management": "4.5.1",
@@ -49,13 +45,6 @@
     },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.ext.flatsharp": {
-      "version": "1.1.1",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
@@ -114,58 +103,6 @@
       "depth": 3,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.nuget.newtonsoft-json": {
-      "version": "3.2.1",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "2.0.0",
-        "com.unity.collections": "2.4.3",
-        "com.unity.inputsystem": "1.10.0",
-        "com.unity.shadergraph": "17.0.3",
-        "com.unity.textmeshpro": "3.0.7",
-        "com.unity.ext.flatsharp": "1.1.1",
-        "com.unity.modules.video": "1.0.0",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.nuget.newtonsoft-json": "3.2.1",
-        "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial.visionos": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.xr.visionos": "2.2.4",
-        "com.unity.xr.management": "4.5.0",
-        "com.unity.polyspatial.xr": "2.2.4"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.polyspatial.xr": {
-      "version": "2.2.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.xr.hands": "1.4.1",
-        "com.unity.inputsystem": "1.10.0",
-        "com.unity.polyspatial": "2.2.4",
-        "com.unity.textmeshpro": "3.0.7",
-        "com.unity.xr.core-utils": "2.3.0",
-        "com.unity.xr.arfoundation": "6.0.3",
-        "com.unity.nuget.newtonsoft-json": "3.2.1"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
@@ -262,14 +199,6 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
-    },
-    "com.unity.textmeshpro": {
-      "version": "5.0.0",
-      "depth": 2,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.ugui": "2.0.0"
-      }
     },
     "com.unity.timeline": {
       "version": "1.8.7",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -140,7 +140,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.2.0
+  bundleVersion: 0.2.1
   preloadedAssets:
   - {fileID: 0}
   - {fileID: 0}

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Right click on the hierarchy window to open the menu. Select `STYLY-XR-Rig` in t
 
 # Features
 - visionOS support
-  - Bounded guide gizmo for visionOS Bounded mode
+  - Bounded guide gizmo for visionOS Bounded mode (requires PolySpatial)
   - Compatible with intractable objects with XR Interaction toolkit (XRI)
-  - VisionOSHoverEffect will be automatically attached to Interactable GameObject
+  - VisionOSHoverEffect will be automatically attached to Interactable GameObject (requires PolySpatial)
 - OpenXR Mixed Reality support
   - Video pass through will be enabled on OpenXR environment
 - Unity Editor development support
@@ -34,8 +34,8 @@ Right click on the hierarchy window to open the menu. Select `STYLY-XR-Rig` in t
 
 # Requirements
 - Unity 6000.0 or higher
-- Unity Pro license
-  - This XR-Rig is open source, however it depends on several Unity packages including PolySpatial which is only provided for Unity Pro developers.
+- Unity Pro license (optional, required only for PolySpatial features)
+  - This XR-Rig is open source and provides core XRI functionality without any additional dependencies. PolySpatial is an optional dependency that enables additional visionOS-specific features like VisionOSHoverEffect and volume camera configuration, but is only available for Unity Pro developers.
 
 # How the Rig is made
 This section is written for maintenance purpose of this repository.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This XR Rig is currently used only in [STYLY for Vision Pro](https://apps.apple.
 
 # How to add STYLY-XR-Rig
 
+## Option 1
+
+```
+openupm add -f com.styly.styly-xr-rig
+```
+
+## Option 2 (If you use [STYLY-Spatial-Layer-Plugin](https://github.com/styly-dev/STYLY-Spatial-Layer-Plugin))
 Right click on the hierarchy window to open the menu. Select `STYLY-XR-Rig` in the `XR` section.  
   
 ![How To Add STYLY XR Rig](https://github.com/styly-dev/STYLY-XR-Rig/assets/387880/e84dde8e-8000-48ec-b5bf-4492d9e6db97)


### PR DESCRIPTION
This pull request introduces conditional support for Unity's PolySpatial package and VisionOS-specific features, while also simplifying dependencies and updating documentation. The most significant changes include adding conditional compilation for PolySpatial features, updating package dependencies, and clarifying the requirements in the documentation.

### VisionOS and PolySpatial Integration:
* [`Packages/com.styly.styly-xr-rig/Runtime/Scripts/AddVisionOSHoverEffect.cs`](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR2-R4): Added conditional compilation (`#if UNITY_VISIONOS && USE_POLYSPATIAL`) for VisionOSHoverEffect functionality to ensure compatibility only when PolySpatial is enabled. [[1]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR2-R4) [[2]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aR17-R26) [[3]](diffhunk://#diff-c4dee0a59e39e5e4e5c8b93d56e9fc45d059094ed06189f02740a8c6d5fd9c2aL64-R70)
* [`Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs`](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R2-R10): Introduced conditional compilation for VisionOS-specific bounded mode configuration and refactored `Awake` method to separate VisionOS initialization logic. [[1]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R2-R10) [[2]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51L25-L32) [[3]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R108-R125)

### Dependency Updates:
* [`Packages/com.styly.styly-xr-rig/package.json`](diffhunk://#diff-8813a66c25c18246e16b8e32bdfb2202c1e48054a6a10fbaa397fc72d4982343L14-R17): Updated package dependencies, removing PolySpatial-related packages and bumping versions for `com.unity.xr.hands` and `com.unity.xr.arfoundation`.
* [`Packages/packages-lock.json`](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL9-R12): Removed entries for PolySpatial and related packages, reflecting updated dependencies. [[1]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL9-R12) [[2]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL119-L170) [[3]](diffhunk://#diff-8ae68780f55772c74938b9d878faafd03740de2b900b4c8cf2b8da6b3b8a775aL394-L417)

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R24): Clarified optional dependency on PolySpatial for VisionOS-specific features and added instructions for installing the XR Rig using OpenUPM. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R45)

### Versioning and Assembly Definition:
* [`Packages/com.styly.styly-xr-rig/package.json`](diffhunk://#diff-8813a66c25c18246e16b8e32bdfb2202c1e48054a6a10fbaa397fc72d4982343L3-R3): Updated package version from `0.2.0` to `0.2.1`.
* [`Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef`](diffhunk://#diff-836aaa52f4e4c9d557e819f7f408d4033188ad52b838f5736b1481da4daf761eL18-R24): Added a version define for `com.unity.polyspatial.visionos` to enable conditional compilation.

### Project Settings:
* [`ProjectSettings/ProjectSettings.asset`](diffhunk://#diff-f1db76edbe0068ccbe4382393c8275c49a9ec78927f9f82b29506a506049adeaL143-R143): Updated the bundle version to match the new package version (`0.2.1`).