### PR TITLE
SwitchToVR/MR via StylyXrRig

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -35,9 +35,9 @@ namespace Styly.XRRig
 
         // --- Public API ---
         private bool passthroughMode;
-        public bool PassthroughMode => passthroughMode;
+        internal bool PassthroughMode => passthroughMode;
 
-        public void SwitchToVR(float duration = 1)
+        internal void SwitchToVR(float duration = 1)
         {
             if (IsRedundant(XRMode.VR)) { return; }
 
@@ -61,7 +61,7 @@ namespace Styly.XRRig
             }
         }
 
-        public void SwitchToMR(float duration = 1)
+        internal void SwitchToMR(float duration = 1)
         {
             if (IsRedundant(XRMode.MR)) { return; }
 

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -8,6 +8,25 @@ namespace Styly.XRRig
     public class StylyXrRig : MonoBehaviour
     {
         [SerializeField] private bool passthroughMode = true;
+        private PassthroughManager passthroughManager;
+
+        public bool PassthroughMode => passthroughManager != null ? passthroughManager.PassthroughMode : passthroughMode;
+
+        public void SwitchToVR(float duration = 1)
+        {
+            if (passthroughManager != null)
+            {
+                passthroughManager.SwitchToVR(duration);
+            }
+        }
+
+        public void SwitchToMR(float duration = 1)
+        {
+            if (passthroughManager != null)
+            {
+                passthroughManager.SwitchToMR(duration);
+            }
+        }
 
 #if UNITY_VISIONOS && USE_POLYSPATIAL
         [SerializeField]
@@ -25,7 +44,6 @@ namespace Styly.XRRig
         // Parameters of Bounded Guide Frame Gizmo
         private Vector3 DefaultBoundedGuideFrameGizmoSize = new(1, 1, 1);
         private Color BoundedGuideFrameGizmoColor = Color.yellow;
-
 
         void CreateVolumeCamera()
         {
@@ -145,11 +163,11 @@ namespace Styly.XRRig
         void Awake()
         {
             AwakeForVisionOS();
+            passthroughManager = GetComponentInChildren<PassthroughManager>(false);
         }
 
         void Start()
         {
-            var passthroughManager = FindFirstObjectByType<PassthroughManager>();
             if (passthroughManager == null) return;
             if (passthroughMode)
             {


### PR DESCRIPTION
This pull request refactors the way passthrough mode and XR mode switching are managed in the XR rig codebase, improving encapsulation and making the `PassthroughManager` methods and properties internal. The main logic for passthrough mode is now accessed through the `StylyXrRig` class, which delegates to its internal `PassthroughManager` instance. This change enhances the clarity of the public API and restricts direct access to passthrough controls.

**Encapsulation and API changes:**

* Made `PassthroughManager.PassthroughMode` property and `SwitchToVR`/`SwitchToMR` methods internal, restricting their access to within the assembly. [[1]](diffhunk://#diff-4920fa02f9da7af57703b6e6905b4dcba9a4cbe6cd3234caf576b86ff131a05eL38-R40) [[2]](diffhunk://#diff-4920fa02f9da7af57703b6e6905b4dcba9a4cbe6cd3234caf576b86ff131a05eL64-R64)

**Delegation and initialization:**

* Added a private `PassthroughManager` field to `StylyXrRig` and initialized it in `Awake` using `GetComponentInChildren`. [[1]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R11-R29) [[2]](diffhunk://#diff-f1ff4074bb3a0ea5ea65eeff00dbc2dcd97f23ed44ea511461198a930d827c51R166-L152)
* Updated `StylyXrRig` to expose public `PassthroughMode` property and `SwitchToVR`/`SwitchToMR` methods, which delegate to the internal `PassthroughManager` if available.

**Minor cleanup:**

* Removed an unused variable declaration in `StylyXrRig` for cleaner code.

Close https://github.com/styly-dev/STYLY-XR-Rig/issues/120