### PR TITLE
Fix: Convert XREALXRLoader type to string in EnableXRPlugin call

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
@@ -22,7 +22,7 @@ namespace Styly.XRRig.SetupSdk
             void Step1()  // Enable the OpenXR Loader
             {
 #if USE_XREAL
-            EnableXRPlugin(BuildTargetGroup.Android, typeof(Unity.XR.XREAL.XREALXRLoader));
+            EnableXRPlugin(BuildTargetGroup.Android, typeof(Unity.XR.XREAL.XREALXRLoader).ToString());
 #endif
                 EditorApplication.delayCall += Step2;
             }


### PR DESCRIPTION
This pull request updates the way the XR plugin is enabled for the XREAL SDK in the `SetUpSdkSettings` method. The change improves compatibility by passing the plugin type as a string rather than a type object.

Compatibility improvement:

* Changed the call to `EnableXRPlugin` in `SetupSdk_XrealSdk.cs` to pass `typeof(Unity.XR.XREAL.XREALXRLoader).ToString()` instead of the type object, which may help avoid type resolution issues during build or runtime.