### PR TITLE
Update XREAL SDK

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
@@ -13,7 +13,7 @@ namespace Styly.XRRig.SetupSdk
 {
     public class SetupSdk_XrealSdk
     {
-        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.0.0.20250314/com.xreal.xr.tar.gz";
+        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.0.0.20250401/com.xreal.xr.tar.gz";
 
         private static void SetUpSdkSettings()
         {


### PR DESCRIPTION
This pull request updates the XREAL SDK package identifier to reference a newer release in the `SetupSdk_XrealSdk` class. This ensures that the project uses the latest version of the XREAL SDK.

* Updated the `packageIdentifier` URL in `SetupSdk_XrealSdk` to point to the XREAL SDK Release 3.0.0.20250401, replacing the previous 3.0.0.20250314 version.