### PR TITLE
Update XREAL SDK package identifier to version 3.1.0

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
@@ -13,7 +13,7 @@ namespace Styly.XRRig.SetupSdk
 {
     public class SetupSdk_XrealSdk
     {
-        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.0.0.20250401/com.xreal.xr.tar.gz";
+        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.1.0.20251125/com.xreal.xr.tar.gz";
 
         private static void SetUpSdkSettings()
         {


### PR DESCRIPTION
This pull request updates the XREAL SDK package used in the project to a newer version. The only change is updating the package download URL to point to version 3.1.0.20251125.

* Updated the `packageIdentifier` in `SetupSdk_XrealSdk.cs` to use XREAL SDK version 3.1.0.20251125 instead of 3.0.0.20250401.