### PR TITLE
Enable autoReferenced in package manifest

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
+++ b/Packages/com.styly.styly-xr-rig/Runtime/com.styly.styly-xr-rig.asmdef
@@ -20,7 +20,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": false,
+    "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [
         {


### PR DESCRIPTION
Enable autoReferenced so content projects can access the package without explicit asmdef configuration.