### PR TITLE
Add namespace and documentation to DisableNearFarInteractorCurveInteractionCaster

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/DisableNearFarInteractorCurveInteractionCaster.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/DisableNearFarInteractorCurveInteractionCaster.cs
@@ -1,16 +1,23 @@
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit.Interactors.Casters;
 
-public class DisableNearFarInteractorCurveInteractionCaster : MonoBehaviour
+namespace Styly.XRRig
 {
-    [SerializeField]
-    CurveInteractionCaster leftNearFarInteractorCurveInteractionCaster;
-    [SerializeField]
-    CurveInteractionCaster rightNearFarInteractorCurveInteractionCaster;
-
-    void Start()
+    /// <summary>
+    /// Disable the hand-tracking interaction ray by setting the cast distance of the NearFarInteractor's CurveInteractionCaster to zero.
+    /// Attach this component to a GameObject and assign the left and right CurveInteractionCaster references, then enable it.
+    /// </summary>
+    public class DisableNearFarInteractorCurveInteractionCaster : MonoBehaviour
     {
-        leftNearFarInteractorCurveInteractionCaster.castDistance = 0f;
-        rightNearFarInteractorCurveInteractionCaster.castDistance = 0f;
+        [SerializeField]
+        CurveInteractionCaster leftNearFarInteractorCurveInteractionCaster;
+        [SerializeField]
+        CurveInteractionCaster rightNearFarInteractorCurveInteractionCaster;
+
+        void Start()
+        {
+            leftNearFarInteractorCurveInteractionCaster.castDistance = 0f;
+            rightNearFarInteractorCurveInteractionCaster.castDistance = 0f;
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR improves code organization and maintainability by adding a namespace declaration and comprehensive documentation to the `DisableNearFarInteractorCurveInteractionCaster` class.

## Key Changes
- Wrapped the class in the `Styly.XRRig` namespace for better code organization
- Added XML documentation comments explaining the class purpose and usage
- Properly indented class members to reflect the namespace structure

## Implementation Details
The class functionality remains unchanged—it continues to disable hand-tracking interaction rays by setting the cast distance of NearFarInteractor's CurveInteractionCaster components to zero. The documentation clarifies that users should attach this component to a GameObject, assign the left and right CurveInteractionCaster references, and enable it to take effect.

https://claude.ai/code/session_01TXnBG5KueP6nYTbaQnk82H