### PR TITLE
XREAL: use dedicated URP asset without AR background feature

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
@@ -13,7 +13,7 @@ namespace Styly.XRRig.SetupSdk
 {
     public class SetupSdk_XrealSdk
     {
-        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.0.0.20250401/com.xreal.xr.tar.gz";
+        private static readonly string packageIdentifier = "https://public-resource.xreal.com/download/XREALSDK_Release_3.1.0.20251125/com.xreal.xr.tar.gz";
 
         private static void SetUpSdkSettings()
         {

--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs
@@ -56,8 +56,8 @@ namespace Styly.XRRig.SetupSdk
                 // Set Android Minimum API Level
                 SetAndroidMinimumApiLevel(AndroidSdkVersions.AndroidApiLevel29);
 
-                // Applies the STYLY Mobile Render Pipeline Asset to the GraphicsSettings and QualitySettings.
-                ApplyStylyPipelineAsset();
+                // Applies the STYLY XREAL Render Pipeline Asset (without ARBackgroundRendererFeature)
+                ApplyStylyXrealPipelineAsset();
 
                 // Use the new input system only
                 UseNewInputSystemOnly();

--- a/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/SetupSdkUtils.cs
+++ b/Packages/com.styly.styly-xr-rig/Editor/SetupSDK/SetupSdkUtils.cs
@@ -27,6 +27,11 @@ namespace Styly.XRRig.SetupSdk
         private static readonly string STYLY_Mobile_RPAsset_path = "Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_Mobile_RPAsset.asset";
 
         /// <summary>
+        /// The path to the STYLY XREAL Render Pipeline Asset (without ARBackgroundRendererFeature).
+        /// </summary>
+        private static readonly string STYLY_XREAL_RPAsset_path = "Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset";
+
+        /// <summary>
         /// Waits for a specified number of frames to pass.
         /// </summary>
         public static Task WaitFramesAsync(int frames)
@@ -173,6 +178,24 @@ namespace Styly.XRRig.SetupSdk
             if (rpAsset == null)
             {
                 Debug.LogError($"Failed to load STYLY Mobile Render Pipeline Asset at {STYLY_Mobile_RPAsset_path}");
+                return;
+            }
+
+            // Apply the Render Pipeline Asset to GraphicsSettings and QualitySettings
+            ApplyPipelineAsset(rpAsset);
+        }
+
+        /// <summary>
+        /// Applies the STYLY XREAL Render Pipeline Asset to the GraphicsSettings and QualitySettings.
+        /// This version uses a renderer without ARBackgroundRendererFeature which is incompatible with XREAL.
+        /// </summary>
+        public static void ApplyStylyXrealPipelineAsset()
+        {
+            // Get the STYLY XREAL Render Pipeline Asset
+            var rpAsset = AssetDatabase.LoadAssetAtPath<RenderPipelineAsset>(STYLY_XREAL_RPAsset_path);
+            if (rpAsset == null)
+            {
+                Debug.LogError($"Failed to load STYLY XREAL Render Pipeline Asset at {STYLY_XREAL_RPAsset_path}");
                 return;
             }
 

--- a/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   m_RendererType: 1
   m_RendererData: {fileID: 0}
   m_RendererDataList:
-  - {fileID: 11400000, guid: 87a770674091c4f6b986c3e5ff82c127, type: 2}
+  - {fileID: 11400000, guid: 4514d4abcf24749e1849fd4494fa1976, type: 2}
   m_DefaultRendererIndex: 0
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 0
@@ -25,7 +25,7 @@ MonoBehaviour:
   m_SupportsTerrainHoles: 1
   m_SupportsHDR: 1
   m_HDRColorBufferPrecision: 1
-  m_MSAA: 4
+  m_MSAA: 1
   m_RenderScale: 0.8
   m_UpscalingFilter: 3
   m_FsrOverrideSharpness: 0

--- a/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
+  m_Name: STYLY_XREAL_RPAsset
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 12
+  k_AssetPreviousVersion: 12
+  m_RendererType: 1
+  m_RendererData: {fileID: 0}
+  m_RendererDataList:
+  - {fileID: 11400000, guid: 87a770674091c4f6b986c3e5ff82c127, type: 2}
+  m_DefaultRendererIndex: 0
+  m_RequireDepthTexture: 0
+  m_RequireOpaqueTexture: 0
+  m_OpaqueDownsampling: 0
+  m_SupportsTerrainHoles: 1
+  m_SupportsHDR: 1
+  m_HDRColorBufferPrecision: 1
+  m_MSAA: 4
+  m_RenderScale: 0.8
+  m_UpscalingFilter: 3
+  m_FsrOverrideSharpness: 0
+  m_FsrSharpness: 0.92
+  m_EnableLODCrossFade: 1
+  m_LODCrossFadeDitheringType: 1
+  m_ShEvalMode: 0
+  m_LightProbeSystem: 0
+  m_ProbeVolumeMemoryBudget: 1024
+  m_ProbeVolumeBlendingMemoryBudget: 256
+  m_SupportProbeVolumeGPUStreaming: 0
+  m_SupportProbeVolumeDiskStreaming: 0
+  m_SupportProbeVolumeScenarios: 0
+  m_SupportProbeVolumeScenarioBlending: 0
+  m_ProbeVolumeSHBands: 1
+  m_MainLightRenderingMode: 1
+  m_MainLightShadowsSupported: 1
+  m_MainLightShadowmapResolution: 1024
+  m_AdditionalLightsRenderingMode: 1
+  m_AdditionalLightsPerObjectLimit: 4
+  m_AdditionalLightShadowsSupported: 0
+  m_AdditionalLightsShadowmapResolution: 2048
+  m_AdditionalLightsShadowResolutionTierLow: 256
+  m_AdditionalLightsShadowResolutionTierMedium: 512
+  m_AdditionalLightsShadowResolutionTierHigh: 1024
+  m_ReflectionProbeBlending: 1
+  m_ReflectionProbeBoxProjection: 1
+  m_ShadowDistance: 50
+  m_ShadowCascadeCount: 1
+  m_Cascade2Split: 0.25
+  m_Cascade3Split: {x: 0.1, y: 0.3}
+  m_Cascade4Split: {x: 0.067, y: 0.2, z: 0.467}
+  m_CascadeBorder: 0.2
+  m_ShadowDepthBias: 1
+  m_ShadowNormalBias: 1
+  m_AnyShadowsSupported: 1
+  m_SoftShadowsSupported: 0
+  m_ConservativeEnclosingSphere: 1
+  m_NumIterationsEnclosingSphere: 64
+  m_SoftShadowQuality: 2
+  m_AdditionalLightsCookieResolution: 1024
+  m_AdditionalLightsCookieFormat: 1
+  m_UseSRPBatcher: 1
+  m_SupportsDynamicBatching: 0
+  m_MixedLightingSupported: 1
+  m_SupportsLightCookies: 1
+  m_SupportsLightLayers: 1
+  m_DebugLevel: 0
+  m_StoreActionsOptimization: 0
+  m_UseAdaptivePerformance: 1
+  m_ColorGradingMode: 0
+  m_ColorGradingLutSize: 32
+  m_AllowPostProcessAlphaOutput: 0
+  m_UseFastSRGBLinearConversion: 1
+  m_SupportDataDrivenLensFlare: 1
+  m_SupportScreenSpaceLensFlare: 1
+  m_GPUResidentDrawerMode: 0
+  m_SmallMeshScreenPercentage: 0
+  m_GPUResidentDrawerEnableOcclusionCullingInCameras: 0
+  m_ShadowType: 1
+  m_LocalShadowsSupported: 0
+  m_LocalShadowsAtlasResolution: 256
+  m_MaxPixelLights: 0
+  m_ShadowAtlasResolution: 256
+  m_VolumeFrameworkUpdateMode: 0
+  m_VolumeProfile: {fileID: 11400000, guid: 10fc4df2da32a41aaa32d77bc913491c, type: 2}
+  apvScenesData:
+    obsoleteSceneBounds:
+      m_Keys: []
+      m_Values: []
+    obsoleteHasProbeVolumes:
+      m_Keys: []
+      m_Values: 
+  m_PrefilteringModeMainLightShadows: 3
+  m_PrefilteringModeAdditionalLight: 0
+  m_PrefilteringModeAdditionalLightShadows: 0
+  m_PrefilterXRKeywords: 0
+  m_PrefilteringModeForwardPlus: 2
+  m_PrefilteringModeDeferredRendering: 0
+  m_PrefilteringModeScreenSpaceOcclusion: 0
+  m_PrefilterDebugKeywords: 1
+  m_PrefilterWriteRenderingLayers: 1
+  m_PrefilterHDROutput: 1
+  m_PrefilterAlphaOutput: 1
+  m_PrefilterSSAODepthNormals: 1
+  m_PrefilterSSAOSourceDepthLow: 1
+  m_PrefilterSSAOSourceDepthMedium: 1
+  m_PrefilterSSAOSourceDepthHigh: 1
+  m_PrefilterSSAOInterleaved: 1
+  m_PrefilterSSAOBlueNoise: 1
+  m_PrefilterSSAOSampleCountLow: 1
+  m_PrefilterSSAOSampleCountMedium: 1
+  m_PrefilterSSAOSampleCountHigh: 1
+  m_PrefilterDBufferMRT1: 1
+  m_PrefilterDBufferMRT2: 1
+  m_PrefilterDBufferMRT3: 1
+  m_PrefilterSoftShadowsQualityLow: 1
+  m_PrefilterSoftShadowsQualityMedium: 1
+  m_PrefilterSoftShadowsQualityHigh: 1
+  m_PrefilterSoftShadows: 0
+  m_PrefilterScreenCoord: 1
+  m_PrefilterNativeRenderPass: 1
+  m_PrefilterUseLegacyLightmaps: 0
+  m_PrefilterReflectionProbeBlending: 0
+  m_PrefilterReflectionProbeBoxProjection: 0
+  m_ShaderVariantLogLevel: 0
+  m_ShadowCascades: 0
+  m_Textures:
+    blueNoise64LTex: {fileID: 2800000, guid: e3d24661c1e055f45a7560c033dbb837, type: 3}
+    bayerMatrixTex: {fileID: 2800000, guid: f9ee4ed84c1d10c49aabb9b210b0fc44, type: 3}

--- a/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset.meta
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88ff486950bc84552b8380de0686ac3d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de640fe3d0db1804a85f9fc8f5cadab6, type: 3}
+  m_Name: STYLY_XREAL_Renderer
+  m_EditorClassIdentifier: 
+  debugShaders:
+    debugReplacementPS: {fileID: 4800000, guid: cf852408f2e174538bcd9b7fda1c5ae7, type: 3}
+    hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
+    probeVolumeSamplingDebugComputeShader: {fileID: 7200000, guid: 53626a513ea68ce47b59dc1299fe3959, type: 3}
+  probeVolumeResources:
+    probeVolumeDebugShader: {fileID: 0}
+    probeVolumeFragmentationDebugShader: {fileID: 0}
+    probeVolumeOffsetDebugShader: {fileID: 0}
+    probeVolumeSamplingDebugShader: {fileID: 0}
+    probeSamplingDebugMesh: {fileID: 0}
+    probeSamplingDebugTexture: {fileID: 0}
+    probeVolumeBlendStatesCS: {fileID: 0}
+  m_RendererFeatures: []
+  m_RendererFeatureMap: 
+  m_UseNativeRenderPass: 1
+  xrSystemData: {fileID: 0}
+  postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  m_AssetVersion: 2
+  m_OpaqueLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_TransparentLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_DefaultStencilState:
+    overrideStencilState: 0
+    stencilReference: 0
+    stencilCompareFunction: 8
+    passOperation: 2
+    failOperation: 0
+    zFailOperation: 0
+  m_ShadowTransparentReceive: 0
+  m_RenderingMode: 2
+  m_DepthPrimingMode: 0
+  m_CopyDepthMode: 0
+  m_DepthAttachmentFormat: 0
+  m_DepthTextureFormat: 0
+  m_AccurateGbufferNormals: 0
+  m_IntermediateTextureMode: 0

--- a/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset.meta
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4514d4abcf24749e1849fd4494fa1976
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Resolves: #148 

## Summary
This PR fixes XREAL display initialization/rendering issues by separating XREAL rendering from the mobile AR renderer path.

## What changed
- Added a dedicated XREAL renderer asset with `ARBackgroundRendererFeature` removed.
- Added a dedicated XREAL URP asset that references the XREAL renderer.
- Updated XREAL to version 3.1.0 from https://public-resource.xreal.com/download/XREALSDK_Release_3.1.0.20251125/com.xreal.xr.tar.gz.
- Updated XREAL setup flow to apply the XREAL URP asset instead of the mobile AR URP asset.
- Added utility support for applying the XREAL pipeline asset across `GraphicsSettings` and all quality levels.

## Files
- [Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs](Packages/com.styly.styly-xr-rig/Editor/SetupSDK/Devices/SetupSdk_XrealSdk.cs)
- [Packages/com.styly.styly-xr-rig/Editor/SetupSDK/SetupSdkUtils.cs](Packages/com.styly.styly-xr-rig/Editor/SetupSDK/SetupSdkUtils.cs)
- [Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset](Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_RPAsset.asset)
- [Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset](Packages/com.styly.styly-xr-rig/Runtime/Settings/STYLY_XREAL_Renderer.asset)

## Why
XREAL OpenXR native display initialization is incompatible with AR camera background rendering behavior. Using an XREAL-specific URP renderer avoids that conflict and preserves platform-specific behavior.

## Validation
- Verified XREAL URP asset references the correct XREAL renderer GUID.
- Verified renderer metadata uses correct `mainObjectFileID` for URP asset resolution.
- Reopened the project and confirmed GUID wiring remains stable.
- Confirmed XREAL SDK tarball can remain untracked; setup still uses remote package URL (no large binary required in git).

## Notes
- No behavior change for non-XREAL targets; existing mobile pipeline path remains unchanged.