### PR TITLE
[codex] Add physical transform movement toggle for controller scripts

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/STYLY XR Rig.prefab
+++ b/Packages/com.styly.styly-xr-rig/Runtime/STYLY XR Rig.prefab
@@ -22,6 +22,8 @@ GameObject:
   - component: {fileID: 7632155229309427778}
   - component: {fileID: 3688553914472423503}
   - component: {fileID: 611438928132686620}
+  - component: {fileID: 6863693838927418023}
+  - component: {fileID: 6647651339540416453}
   - component: {fileID: 6724786742393489301}
   - component: {fileID: 4092345172134132238}
   m_Layer: 2
@@ -230,6 +232,102 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   xriActions: {fileID: -944628639613478452, guid: c348712bda248c246b8c49b3db54643f,
     type: 3}
+--- !u!114 &6863693838927418023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8257337966620525994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ad7d9ccec2bb44c4b0797d02ca2e0f3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 932545197216251794}
+  moveSpeed: 5
+  lookSensitivity: 8
+  snapTurnDegrees: 45
+--- !u!114 &6647651339540416453
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8257337966620525994}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b7de3e7974a54b6eaa9f0b6ee1c46c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveAction:
+    m_UseReference: 1
+    m_Action:
+      m_Name: Move
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: 4e95e582-0d91-4def-a08a-e1eed8bf350e
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: 6972639530819350904, guid: c348712bda248c246b8c49b3db54643f,
+      type: 3}
+  snapTurnAction:
+    m_UseReference: 1
+    m_Action:
+      m_Name: Snap Turn
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: 1d26668f-5ee9-4af9-a223-6b493eac1c7b
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings: []
+      m_Flags: 0
+    m_Reference: {fileID: -8525429354371678379, guid: c348712bda248c246b8c49b3db54643f,
+      type: 3}
+  verticalUpAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Vertical Up
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: ffc71052-9831-42f5-8819-dd4d5beead68
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 6c994190-0fcc-46eb-8819-dc4678f2a3d0
+        m_Path: <XRController>{LeftHand}/{SecondaryButton}
+        m_Interactions: Press
+        m_Processors: 
+        m_Groups: 
+        m_Action: Vertical Up
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  verticalDownAction:
+    m_UseReference: 0
+    m_Action:
+      m_Name: Vertical Down
+      m_Type: 0
+      m_ExpectedControlType: 
+      m_Id: 69b15f27-d810-480e-bac0-3a2bd331c501
+      m_Processors: 
+      m_Interactions: 
+      m_SingletonActionBindings:
+      - m_Name: 
+        m_Id: 4e07ffe5-5f5b-41cc-b149-308c0419862a
+        m_Path: <XRController>{LeftHand}/{PrimaryButton}
+        m_Interactions: Press
+        m_Processors: 
+        m_Groups: 
+        m_Action: Vertical Down
+        m_Flags: 0
+      m_Flags: 0
+    m_Reference: {fileID: 0}
+  moveSpeed: 2
+  snapTurnDegrees: 45
 --- !u!114 &6724786742393489301
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Packages/com.styly.styly-xr-rig/Runtime/STYLY XR Rig.prefab
+++ b/Packages/com.styly.styly-xr-rig/Runtime/STYLY XR Rig.prefab
@@ -298,7 +298,7 @@ MonoBehaviour:
       m_SingletonActionBindings:
       - m_Name: 
         m_Id: 6c994190-0fcc-46eb-8819-dc4678f2a3d0
-        m_Path: <XRController>{LeftHand}/{SecondaryButton}
+        m_Path: <XRController>{LeftHand}/{PrimaryButton}
         m_Interactions: Press
         m_Processors: 
         m_Groups: 
@@ -318,7 +318,7 @@ MonoBehaviour:
       m_SingletonActionBindings:
       - m_Name: 
         m_Id: 4e07ffe5-5f5b-41cc-b149-308c0419862a
-        m_Path: <XRController>{LeftHand}/{PrimaryButton}
+        m_Path: <XRController>{LeftHand}/{SecondaryButton}
         m_Interactions: Press
         m_Processors: 
         m_Groups: 

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
@@ -86,16 +86,18 @@ namespace Styly.XRRig
 
             // Use camera's forward/right to account for Camera Offset rotation
             Transform directionSource = cameraTransform != null ? cameraTransform : controlTarget;
+            Vector3 forward = ProjectDirectionOnGround(directionSource.forward, Vector3.forward);
+            Vector3 right = ProjectDirectionOnGround(directionSource.right, Vector3.right);
 
             // XZ plane movement (WASD)
             if (keyboard.wKey.isPressed)
-                moveDirection += directionSource.forward;
+                moveDirection += forward;
             if (keyboard.sKey.isPressed)
-                moveDirection -= directionSource.forward;
+                moveDirection -= forward;
             if (keyboard.aKey.isPressed)
-                moveDirection -= directionSource.right;
+                moveDirection -= right;
             if (keyboard.dKey.isPressed)
-                moveDirection += directionSource.right;
+                moveDirection += right;
 
             // Y axis movement (E/Q)
             if (keyboard.eKey.isPressed)
@@ -181,6 +183,18 @@ namespace Styly.XRRig
             {
                 controlTarget.position += worldDelta;
             }
+        }
+
+        private static Vector3 ProjectDirectionOnGround(Vector3 direction, Vector3 fallback)
+        {
+            Vector3 projected = Vector3.ProjectOnPlane(direction, Vector3.up);
+            if (projected.sqrMagnitude > 0.0001f)
+            {
+                projected.Normalize();
+                return projected;
+            }
+
+            return fallback;
         }
 
         private static void MoveTransformByWorldDelta(Transform targetTransform, Vector3 worldDelta)

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEditor;
 
 namespace Styly.XRRig
 {
@@ -11,6 +10,9 @@ namespace Styly.XRRig
     public class EditorPlayerController : MonoBehaviour
     {
         [Header("Target")][SerializeField] private Transform target;
+
+        [SerializeField, InspectorName("Move Physical Transform")]
+        private bool movePhysicalTransform = true;
 
         [Header("Movement Settings (WASD + EQ)")]
         [SerializeField]
@@ -29,6 +31,7 @@ namespace Styly.XRRig
         private Transform controlTarget;
         private Transform cameraTransform;
         private Transform cameraOffsetTransform;
+        private Transform physicalTarget;
         private float rotationX = 0f;
         private float rotationY = 0f;
         private float lastSnapTime = -999f;
@@ -42,6 +45,8 @@ namespace Styly.XRRig
             if (Camera.main != null)
             {
                 cameraTransform = Camera.main.transform;
+                physicalTarget = cameraTransform.parent != null ? cameraTransform.parent : cameraTransform;
+
                 // Camera Offset is the parent of Main Camera
                 if (cameraTransform.parent != null && cameraTransform.parent != controlTarget)
                 {
@@ -102,7 +107,7 @@ namespace Styly.XRRig
             if (moveDirection.magnitude > 0)
             {
                 moveDirection.Normalize();
-                controlTarget.position += moveDirection * moveSpeed * Time.deltaTime;
+                ApplyWorldMovement(moveDirection * moveSpeed * Time.deltaTime);
             }
         }
 
@@ -128,8 +133,7 @@ namespace Styly.XRRig
                 // Desired camera world rotation
                 Quaternion desiredRotation = Quaternion.Euler(rotationX, rotationY, 0);
 
-                // Rotate around camera position so the view doesn't orbit when Camera Offset has a position
-                RotateControlTargetForCamera(desiredRotation);
+                ApplyCameraRotation(desiredRotation);
             }
         }
 
@@ -161,8 +165,80 @@ namespace Styly.XRRig
 
             rotationY += snapTurnDegrees * direction;
             Quaternion desiredRotation = Quaternion.Euler(rotationX, rotationY, 0);
-            RotateControlTargetForCamera(desiredRotation);
+            ApplyCameraRotation(desiredRotation);
             lastSnapTime = now;
+        }
+
+        private void ApplyWorldMovement(Vector3 worldDelta)
+        {
+            if (movePhysicalTransform && physicalTarget != null)
+            {
+                MoveTransformByWorldDelta(physicalTarget, worldDelta);
+                return;
+            }
+
+            if (controlTarget != null)
+            {
+                controlTarget.position += worldDelta;
+            }
+        }
+
+        private static void MoveTransformByWorldDelta(Transform targetTransform, Vector3 worldDelta)
+        {
+            if (targetTransform == null) return;
+
+            Transform parent = targetTransform.parent;
+            if (parent != null)
+            {
+                targetTransform.localPosition += parent.InverseTransformVector(worldDelta);
+                return;
+            }
+
+            targetTransform.position += worldDelta;
+        }
+
+        private void ApplyCameraRotation(Quaternion desiredCameraRotation)
+        {
+            if (movePhysicalTransform && physicalTarget != null)
+            {
+                RotatePhysicalTargetForCamera(desiredCameraRotation);
+                return;
+            }
+
+            RotateControlTargetForCamera(desiredCameraRotation);
+        }
+
+        private void RotatePhysicalTargetForCamera(Quaternion desiredCameraRotation)
+        {
+            if (physicalTarget == null)
+            {
+                RotateControlTargetForCamera(desiredCameraRotation);
+                return;
+            }
+
+            if (cameraTransform != null && cameraTransform != physicalTarget && cameraTransform.IsChildOf(physicalTarget))
+            {
+                Quaternion cameraRelativeRotation = Quaternion.Inverse(physicalTarget.rotation) * cameraTransform.rotation;
+                Quaternion desiredPhysicalWorldRotation = desiredCameraRotation * Quaternion.Inverse(cameraRelativeRotation);
+                SetWorldRotationAsLocal(physicalTarget, desiredPhysicalWorldRotation);
+                return;
+            }
+
+            SetWorldRotationAsLocal(physicalTarget, desiredCameraRotation);
+        }
+
+        private static void SetWorldRotationAsLocal(Transform targetTransform, Quaternion worldRotation)
+        {
+            if (targetTransform == null) return;
+
+            Transform parent = targetTransform.parent;
+            if (parent != null)
+            {
+                targetTransform.localRotation = Quaternion.Inverse(parent.rotation) * worldRotation;
+                return;
+            }
+
+            targetTransform.localRotation = worldRotation;
         }
 
         /// <summary>

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
@@ -1,0 +1,204 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEditor;
+
+namespace Styly.XRRig
+{
+    /// <summary>
+    /// Controller for operating local avatar in the editor
+    /// </summary>
+#if UNITY_EDITOR
+    public class EditorPlayerController : MonoBehaviour
+    {
+        [Header("Target")][SerializeField] private Transform target;
+
+        [Header("Movement Settings (WASD + EQ)")]
+        [SerializeField]
+        private float moveSpeed = 5f;
+
+        [Header("Look Settings")]
+        [SerializeField]
+        private float lookSensitivity = 8f;
+
+        [Header("Snap Turn (Left/Right Arrow Keys)")]
+        [SerializeField]
+        private float snapTurnDegrees = 45f;
+
+        private float snapTurnDebounce = 0.25f;
+
+        private Transform controlTarget;
+        private Transform cameraTransform;
+        private Transform cameraOffsetTransform;
+        private float rotationX = 0f;
+        private float rotationY = 0f;
+        private float lastSnapTime = -999f;
+
+        void Start()
+        {
+            // Set control target (use self if target is null)
+            controlTarget = target != null ? target : transform;
+
+            // Get Main Camera and Camera Offset transforms
+            if (Camera.main != null)
+            {
+                cameraTransform = Camera.main.transform;
+                // Camera Offset is the parent of Main Camera
+                if (cameraTransform.parent != null && cameraTransform.parent != controlTarget)
+                {
+                    cameraOffsetTransform = cameraTransform.parent;
+                }
+            }
+
+            // Preserve current rotation based on camera's world rotation
+            if (cameraTransform != null)
+            {
+                rotationY = cameraTransform.eulerAngles.y;
+                rotationX = cameraTransform.eulerAngles.x;
+            }
+            else
+            {
+                rotationY = controlTarget.eulerAngles.y;
+                rotationX = controlTarget.eulerAngles.x;
+            }
+        }
+
+        void Update()
+        {
+            HandleMovement();
+            HandleRotation();
+            HandleSnapTurn();
+        }
+
+        /// <summary>
+        /// Movement handling with WASD (XZ plane) and EQ (Y axis)
+        /// </summary>
+        private void HandleMovement()
+        {
+            Vector3 moveDirection = Vector3.zero;
+            Keyboard keyboard = Keyboard.current;
+
+            if (keyboard == null) return;
+
+            // Use camera's forward/right to account for Camera Offset rotation
+            Transform directionSource = cameraTransform != null ? cameraTransform : controlTarget;
+
+            // XZ plane movement (WASD)
+            if (keyboard.wKey.isPressed)
+                moveDirection += directionSource.forward;
+            if (keyboard.sKey.isPressed)
+                moveDirection -= directionSource.forward;
+            if (keyboard.aKey.isPressed)
+                moveDirection -= directionSource.right;
+            if (keyboard.dKey.isPressed)
+                moveDirection += directionSource.right;
+
+            // Y axis movement (E/Q)
+            if (keyboard.eKey.isPressed)
+                moveDirection += Vector3.up;
+            if (keyboard.qKey.isPressed)
+                moveDirection -= Vector3.up;
+
+            // Apply movement
+            if (moveDirection.magnitude > 0)
+            {
+                moveDirection.Normalize();
+                controlTarget.position += moveDirection * moveSpeed * Time.deltaTime;
+            }
+        }
+
+        /// <summary>
+        /// View rotation handling with right mouse button drag
+        /// </summary>
+        private void HandleRotation()
+        {
+            Mouse mouse = Mouse.current;
+            if (mouse == null) return;
+
+            // Rotate only while right-clicking
+            if (mouse.rightButton.isPressed)
+            {
+                Vector2 mouseDelta = mouse.delta.ReadValue() * lookSensitivity * 0.1f;
+
+                rotationY += mouseDelta.x;
+                rotationX -= mouseDelta.y;
+
+                // Vertical angle limit
+                rotationX = Mathf.Clamp(rotationX, -90f, 90f);
+
+                // Desired camera world rotation
+                Quaternion desiredRotation = Quaternion.Euler(rotationX, rotationY, 0);
+
+                // Rotate around camera position so the view doesn't orbit when Camera Offset has a position
+                RotateControlTargetForCamera(desiredRotation);
+            }
+        }
+
+        /// <summary>
+        /// Snap turn handling with left/right arrow keys
+        /// </summary>
+        private void HandleSnapTurn()
+        {
+            Keyboard keyboard = Keyboard.current;
+            if (keyboard == null) return;
+
+            if (controlTarget == null) return;
+
+            bool rightPressed = keyboard.rightArrowKey.wasPressedThisFrame;
+            bool leftPressed = keyboard.leftArrowKey.wasPressedThisFrame;
+
+            if (!rightPressed && !leftPressed) return;
+
+            float now = Time.time;
+            if (now - lastSnapTime < snapTurnDebounce) return;
+
+            float direction = rightPressed ? 1f : -1f;
+            if (rightPressed && leftPressed)
+            {
+                direction = 0f;
+            }
+
+            if (Mathf.Approximately(direction, 0f)) return;
+
+            rotationY += snapTurnDegrees * direction;
+            Quaternion desiredRotation = Quaternion.Euler(rotationX, rotationY, 0);
+            RotateControlTargetForCamera(desiredRotation);
+            lastSnapTime = now;
+        }
+
+        /// <summary>
+        /// Set controlTarget rotation so the camera achieves the desired world rotation,
+        /// adjusting position to rotate around the camera (not the rig root).
+        /// </summary>
+        private void RotateControlTargetForCamera(Quaternion desiredCameraRotation)
+        {
+            if (cameraTransform == null)
+            {
+                controlTarget.rotation = desiredCameraRotation;
+                return;
+            }
+
+            // Remember camera world position before rotation
+            Vector3 cameraWorldPos = cameraTransform.position;
+
+            // Compute controlTarget rotation that achieves desired camera rotation
+            if (cameraOffsetTransform != null)
+            {
+                controlTarget.rotation = desiredCameraRotation * Quaternion.Inverse(cameraOffsetTransform.localRotation);
+            }
+            else
+            {
+                controlTarget.rotation = desiredCameraRotation;
+            }
+
+            // After rotation, camera has moved — shift controlTarget so camera returns to its original position
+            Vector3 cameraNewPos = cameraTransform.position;
+            controlTarget.position += cameraWorldPos - cameraNewPos;
+        }
+    }
+#else
+    public class EditorPlayerController : MonoBehaviour
+    {
+        // Do nothing outside the editor
+    }
+#endif
+}

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs.meta
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ad7d9ccec2bb44c4b0797d02ca2e0f3

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
@@ -6,8 +6,7 @@ namespace Styly.XRRig
 {
     public class VrStickController : MonoBehaviour
     {
-        // Error message constant
-        private const string MoveTargetNotSetError = "VrStickController: moveTarget is not set. Please assign the Transform to move in the Inspector.";
+        private const string MoveTargetNotAvailableError = "VrStickController: No movement target is available. Enable a Main Camera for physical movement, or add STYLY XR Rig for virtual movement.";
 
         [Header("Input Actions (assign in Inspector)")]
         [Tooltip("Assign \"XRI Left Locomotion/Move\" from Starter Assets/XRI Default Input Actions")]
@@ -16,10 +15,10 @@ namespace Styly.XRRig
         [Tooltip("Assign \"XRI Right Locomotion/Snap Turn\" from Starter Assets/XRI Default Input Actions")]
         public InputActionProperty snapTurnAction;
 
-        [Tooltip("Assign an Input Action that fires when the X button is pressed to move upward")]
+        [Tooltip("Assign an Input Action that fires when the vertical up button is pressed")]
         public InputActionProperty verticalUpAction;
 
-        [Tooltip("Assign an Input Action that fires when the Y button is pressed to move downward")]
+        [Tooltip("Assign an Input Action that fires when the vertical down button is pressed")]
         public InputActionProperty verticalDownAction;
 
         // Head (Main Camera) will be assigned
@@ -53,6 +52,7 @@ namespace Styly.XRRig
         // Internal state
         float _prevSnapValue = 0f;
         float _lastSnapTime = -999f;
+        private bool hasLoggedMoveTargetError = false;
 
         private const float ButtonPressedThreshold = 0.5f;
 
@@ -61,16 +61,14 @@ namespace Styly.XRRig
         {
             ResolveCameraTargets();
 
-            // Remove redundant assignment as it's already done in Awake
-            // Only find and assign moveTarget with proper null checking
-            var stylyXrRig = FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
+            var stylyXrRig = FindFirstObjectByType<StylyXrRig>();
             if (stylyXrRig != null)
             {
                 moveTarget = stylyXrRig.transform;
             }
-            else
+            else if (!HasActiveMoveTarget())
             {
-                Debug.LogError("VrStickController: No StylyXrRig found in the scene. Please ensure STYLY XR Rig is present.");
+                LogMoveTargetErrorOnce();
             }
         }
 
@@ -104,7 +102,7 @@ namespace Styly.XRRig
 
             if (!HasActiveMoveTarget())
             {
-                Debug.LogError(MoveTargetNotSetError);
+                LogMoveTargetErrorOnce();
                 return;
             }
 
@@ -152,7 +150,7 @@ namespace Styly.XRRig
 
             if (!HasActiveMoveTarget())
             {
-                Debug.LogError(MoveTargetNotSetError);
+                LogMoveTargetErrorOnce();
                 return;
             }
 
@@ -218,7 +216,7 @@ namespace Styly.XRRig
 
             if (!HasActiveMoveTarget())
             {
-                Debug.LogError(MoveTargetNotSetError);
+                LogMoveTargetErrorOnce();
                 return;
             }
 
@@ -300,6 +298,14 @@ namespace Styly.XRRig
             return moveTarget != null;
         }
 
+        private void LogMoveTargetErrorOnce()
+        {
+            if (hasLoggedMoveTargetError) return;
+
+            Debug.LogError(MoveTargetNotAvailableError);
+            hasLoggedMoveTargetError = true;
+        }
+
         private void ApplyWorldMovement(Vector3 worldDelta)
         {
             if (movePhysicalTransform)
@@ -370,11 +376,6 @@ namespace Styly.XRRig
         void OnValidate()
         {
             ResolveCameraTargets();
-
-            if (!HasActiveMoveTarget())
-            {
-                Debug.LogWarning(MoveTargetNotSetError);
-            }
 
             moveSpeed = Mathf.Max(0f, moveSpeed);
             snapTurnDegrees = Mathf.Clamp(snapTurnDegrees, 1f, 180f);

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using Unity.XR.CoreUtils;
 using UnityEngine;
 using UnityEngine.InputSystem;
 
@@ -31,6 +33,14 @@ namespace Styly.XRRig
         private bool movePhysicalTransform = true;
 
         private Transform physicalTarget;
+        private XROrigin physicalXrOrigin;
+        private bool netSyncReflectionResolved;
+        private Type netSyncManagerType;
+        private PropertyInfo netSyncInstanceProperty;
+        private FieldInfo netSyncXrOriginTransformField;
+        private FieldInfo netSyncPhysicalOffsetPositionField;
+        private FieldInfo netSyncPhysicalOffsetRotationField;
+        private bool hasLoggedNetSyncRebaseError;
 
         [Tooltip("Move speed (m/s)")]
         public float moveSpeed = 2.0f;
@@ -59,14 +69,15 @@ namespace Styly.XRRig
 
         void Start()
         {
-            ResolveCameraTargets();
-
             var stylyXrRig = FindFirstObjectByType<StylyXrRig>();
             if (stylyXrRig != null)
             {
                 moveTarget = stylyXrRig.transform;
             }
-            else if (!HasActiveMoveTarget())
+
+            ResolveCameraTargets();
+
+            if (!HasActiveMoveTarget())
             {
                 LogMoveTargetErrorOnce();
             }
@@ -278,10 +289,45 @@ namespace Styly.XRRig
                 }
             }
 
-            if (physicalTarget == null && headTransform != null)
+            if (physicalTarget == null)
             {
-                physicalTarget = headTransform.parent != null ? headTransform.parent : headTransform;
+                physicalTarget = ResolvePhysicalTarget();
             }
+        }
+
+        private Transform ResolvePhysicalTarget()
+        {
+            // NetSync observes the XR Origin locomotion delta, so prefer the origin over Camera Offset.
+            if (physicalXrOrigin == null && headTransform != null)
+            {
+                physicalXrOrigin = headTransform.GetComponentInParent<XROrigin>();
+            }
+
+            if (physicalXrOrigin == null)
+            {
+                physicalXrOrigin = FindFirstObjectByType<XROrigin>();
+            }
+
+            if (physicalXrOrigin != null)
+            {
+                Transform xrOriginTransform = physicalXrOrigin.transform;
+                if (xrOriginTransform != null)
+                {
+                    return xrOriginTransform;
+                }
+            }
+
+            if (moveTarget != null)
+            {
+                return moveTarget;
+            }
+
+            if (headTransform != null)
+            {
+                return headTransform.parent != null ? headTransform.parent : headTransform;
+            }
+
+            return null;
         }
 
         private bool HasActiveMoveTarget()
@@ -313,7 +359,22 @@ namespace Styly.XRRig
                 ResolveCameraTargets();
                 if (physicalTarget != null)
                 {
+                    if (physicalXrOrigin != null)
+                    {
+                        Camera xrCamera = physicalXrOrigin.Camera;
+                        if (xrCamera != null)
+                        {
+                            Vector3 desiredCameraPosition = xrCamera.transform.position + worldDelta;
+                            if (physicalXrOrigin.MoveCameraToWorldLocation(desiredCameraPosition))
+                            {
+                                RebaseNetSyncPhysicalOrigin();
+                                return;
+                            }
+                        }
+                    }
+
                     MoveTransformByWorldDelta(physicalTarget, worldDelta);
+                    RebaseNetSyncPhysicalOrigin();
                     return;
                 }
             }
@@ -345,8 +406,15 @@ namespace Styly.XRRig
                 ResolveCameraTargets();
                 if (physicalTarget != null)
                 {
+                    if (physicalXrOrigin != null && physicalXrOrigin.RotateAroundCameraUsingOriginUp(degrees))
+                    {
+                        RebaseNetSyncPhysicalOrigin();
+                        return;
+                    }
+
                     Quaternion desiredWorldRotation = Quaternion.Euler(0f, degrees, 0f) * physicalTarget.rotation;
                     SetWorldRotationAsLocal(physicalTarget, desiredWorldRotation);
+                    RebaseNetSyncPhysicalOrigin();
                     return;
                 }
             }
@@ -370,6 +438,96 @@ namespace Styly.XRRig
             }
 
             targetTransform.localRotation = worldRotation;
+        }
+
+        private void RebaseNetSyncPhysicalOrigin()
+        {
+            if (physicalTarget == null) return;
+            if (!TryGetNetSyncManager(out object netSyncManager)) return;
+
+            try
+            {
+                if (netSyncXrOriginTransformField != null && physicalXrOrigin != null)
+                {
+                    Transform xrOriginTransform = physicalXrOrigin.transform;
+                    if (xrOriginTransform != null)
+                    {
+                        netSyncXrOriginTransformField.SetValue(netSyncManager, xrOriginTransform);
+                    }
+                }
+
+                netSyncPhysicalOffsetPositionField.SetValue(netSyncManager, physicalTarget.position);
+                netSyncPhysicalOffsetRotationField.SetValue(netSyncManager, physicalTarget.eulerAngles);
+            }
+            catch (Exception ex)
+            {
+                if (!hasLoggedNetSyncRebaseError)
+                {
+                    Debug.LogWarning($"VrStickController: Failed to rebase STYLY NetSync physical origin: {ex.Message}");
+                    hasLoggedNetSyncRebaseError = true;
+                }
+            }
+        }
+
+        private bool TryGetNetSyncManager(out object netSyncManager)
+        {
+            netSyncManager = null;
+            if (!EnsureNetSyncReflection()) return false;
+
+            object instance = netSyncInstanceProperty.GetValue(null, null);
+            UnityEngine.Object unityInstance = instance as UnityEngine.Object;
+            if (unityInstance == null) return false;
+
+            netSyncManager = instance;
+            return true;
+        }
+
+        private bool EnsureNetSyncReflection()
+        {
+            if (netSyncReflectionResolved)
+            {
+                return netSyncManagerType != null
+                    && netSyncInstanceProperty != null
+                    && netSyncPhysicalOffsetPositionField != null
+                    && netSyncPhysicalOffsetRotationField != null;
+            }
+
+            netSyncReflectionResolved = true;
+            netSyncManagerType = ResolveNetSyncManagerType();
+            if (netSyncManagerType == null) return false;
+
+            BindingFlags staticFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+            netSyncInstanceProperty = netSyncManagerType.GetProperty("Instance", staticFlags);
+
+            BindingFlags instanceFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            netSyncXrOriginTransformField = netSyncManagerType.GetField("_XrOriginTransform", instanceFlags);
+            netSyncPhysicalOffsetPositionField = netSyncManagerType.GetField("_physicalOffsetPosition", instanceFlags);
+            netSyncPhysicalOffsetRotationField = netSyncManagerType.GetField("_physicalOffsetRotation", instanceFlags);
+
+            return netSyncInstanceProperty != null
+                && netSyncPhysicalOffsetPositionField != null
+                && netSyncPhysicalOffsetRotationField != null;
+        }
+
+        private static Type ResolveNetSyncManagerType()
+        {
+            Type managerType = Type.GetType("Styly.NetSync.NetSyncManager, com.styly.styly-netsync");
+            if (managerType != null)
+            {
+                return managerType;
+            }
+
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                managerType = assemblies[i].GetType("Styly.NetSync.NetSyncManager");
+                if (managerType != null)
+                {
+                    return managerType;
+                }
+            }
+
+            return null;
         }
 
 #if UNITY_EDITOR

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
@@ -28,6 +28,11 @@ namespace Styly.XRRig
         // STYLY XR Rig root will be assigned
         private Transform moveTarget;
 
+        [SerializeField, InspectorName("Move Physical Transform")]
+        private bool movePhysicalTransform = true;
+
+        private Transform physicalTarget;
+
         [Tooltip("Move speed (m/s)")]
         public float moveSpeed = 2.0f;
 
@@ -54,10 +59,8 @@ namespace Styly.XRRig
 
         void Start()
         {
-            // Use Main Camera if not explicitly specified
-            if (headTransform == null && Camera.main != null)
-                headTransform = Camera.main.transform;
-            
+            ResolveCameraTargets();
+
             // Remove redundant assignment as it's already done in Awake
             // Only find and assign moveTarget with proper null checking
             var stylyXrRig = FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
@@ -99,7 +102,7 @@ namespace Styly.XRRig
         {
             if (moveAction.action == null) return;
 
-            if (moveTarget == null)
+            if (!HasActiveMoveTarget())
             {
                 Debug.LogError(MoveTargetNotSetError);
                 return;
@@ -122,8 +125,8 @@ namespace Styly.XRRig
             if (move.sqrMagnitude < 0.0001f) return;
 
             // Forward and right vectors based on head (camera)
-            Vector3 forward = headTransform ? headTransform.forward : transform.forward;
-            Vector3 right = headTransform ? headTransform.right : transform.right;
+            Vector3 forward = headTransform != null ? headTransform.forward : transform.forward;
+            Vector3 right = headTransform != null ? headTransform.right : transform.right;
 
             if (flattenToGroundPlane)
             {
@@ -137,7 +140,7 @@ namespace Styly.XRRig
             }
 
             Vector3 worldMove = forward * move.y + right * move.x;
-            moveTarget.position += worldMove * moveSpeed * Time.deltaTime;
+            ApplyWorldMovement(worldMove * moveSpeed * Time.deltaTime);
         }
 
         void HandleVerticalMove()
@@ -147,7 +150,7 @@ namespace Styly.XRRig
 
             if (!hasUpAction && !hasDownAction) return;
 
-            if (moveTarget == null)
+            if (!HasActiveMoveTarget())
             {
                 Debug.LogError(MoveTargetNotSetError);
                 return;
@@ -206,14 +209,14 @@ namespace Styly.XRRig
             if (verticalDirection.sqrMagnitude < 0.0001f) return;
 
             verticalDirection.Normalize();
-            moveTarget.position += verticalDirection * moveSpeed * Time.deltaTime;
+            ApplyWorldMovement(verticalDirection * moveSpeed * Time.deltaTime);
         }
 
         void HandleSnapTurn()
         {
             if (snapTurnAction.action == null) return;
 
-            if (moveTarget == null)
+            if (!HasActiveMoveTarget())
             {
                 Debug.LogError(MoveTargetNotSetError);
                 return;
@@ -225,7 +228,11 @@ namespace Styly.XRRig
                 // XRI Snap Turn is often mapped to float or Vector2.x
                 // InputAction itself has no valueType, so check from bound control
                 var action = snapTurnAction.action;
-                InputControl control = action.activeControl ?? (action.controls.Count > 0 ? action.controls[0] : null);
+                InputControl control = action.activeControl;
+                if (control == null && action.controls.Count > 0)
+                {
+                    control = action.controls[0];
+                }
                 Type ctrlType = control != null ? control.valueType : null;
 
                 if (ctrlType == typeof(Vector2))
@@ -255,21 +262,116 @@ namespace Styly.XRRig
             if ((risingRight || fallingLeft) && (now - _lastSnapTime >= snapTurnDebounce))
             {
                 float dir = risingRight ? +1f : -1f;
-                // Rotate horizontally (Y axis in world space)
-                moveTarget.Rotate(0f, snapTurnDegrees * dir, 0f, Space.World);
+                ApplyYawRotation(snapTurnDegrees * dir);
                 _lastSnapTime = now;
             }
 
             _prevSnapValue = raw;
         }
 
+        private void ResolveCameraTargets()
+        {
+            if (headTransform == null)
+            {
+                Camera mainCamera = Camera.main;
+                if (mainCamera != null)
+                {
+                    headTransform = mainCamera.transform;
+                }
+            }
+
+            if (physicalTarget == null && headTransform != null)
+            {
+                physicalTarget = headTransform.parent != null ? headTransform.parent : headTransform;
+            }
+        }
+
+        private bool HasActiveMoveTarget()
+        {
+            if (movePhysicalTransform)
+            {
+                ResolveCameraTargets();
+                if (physicalTarget != null)
+                {
+                    return true;
+                }
+            }
+
+            return moveTarget != null;
+        }
+
+        private void ApplyWorldMovement(Vector3 worldDelta)
+        {
+            if (movePhysicalTransform)
+            {
+                ResolveCameraTargets();
+                if (physicalTarget != null)
+                {
+                    MoveTransformByWorldDelta(physicalTarget, worldDelta);
+                    return;
+                }
+            }
+
+            if (moveTarget != null)
+            {
+                moveTarget.position += worldDelta;
+            }
+        }
+
+        private static void MoveTransformByWorldDelta(Transform targetTransform, Vector3 worldDelta)
+        {
+            if (targetTransform == null) return;
+
+            Transform parent = targetTransform.parent;
+            if (parent != null)
+            {
+                targetTransform.localPosition += parent.InverseTransformVector(worldDelta);
+                return;
+            }
+
+            targetTransform.position += worldDelta;
+        }
+
+        private void ApplyYawRotation(float degrees)
+        {
+            if (movePhysicalTransform)
+            {
+                ResolveCameraTargets();
+                if (physicalTarget != null)
+                {
+                    Quaternion desiredWorldRotation = Quaternion.Euler(0f, degrees, 0f) * physicalTarget.rotation;
+                    SetWorldRotationAsLocal(physicalTarget, desiredWorldRotation);
+                    return;
+                }
+            }
+
+            if (moveTarget != null)
+            {
+                // Rotate horizontally (Y axis in world space)
+                moveTarget.Rotate(0f, degrees, 0f, Space.World);
+            }
+        }
+
+        private static void SetWorldRotationAsLocal(Transform targetTransform, Quaternion worldRotation)
+        {
+            if (targetTransform == null) return;
+
+            Transform parent = targetTransform.parent;
+            if (parent != null)
+            {
+                targetTransform.localRotation = Quaternion.Inverse(parent.rotation) * worldRotation;
+                return;
+            }
+
+            targetTransform.localRotation = worldRotation;
+        }
+
 #if UNITY_EDITOR
         void OnValidate()
         {
-            if (headTransform == null && Camera.main != null)
-                headTransform = Camera.main.transform;
+            ResolveCameraTargets();
 
-            if (moveTarget == null)
+            if (!HasActiveMoveTarget())
             {
                 Debug.LogWarning(MoveTargetNotSetError);
             }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs
@@ -1,0 +1,283 @@
+using System;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+namespace Styly.XRRig
+{
+    public class VrStickController : MonoBehaviour
+    {
+        // Error message constant
+        private const string MoveTargetNotSetError = "VrStickController: moveTarget is not set. Please assign the Transform to move in the Inspector.";
+
+        [Header("Input Actions (assign in Inspector)")]
+        [Tooltip("Assign \"XRI Left Locomotion/Move\" from Starter Assets/XRI Default Input Actions")]
+        public InputActionProperty moveAction;
+
+        [Tooltip("Assign \"XRI Right Locomotion/Snap Turn\" from Starter Assets/XRI Default Input Actions")]
+        public InputActionProperty snapTurnAction;
+
+        [Tooltip("Assign an Input Action that fires when the X button is pressed to move upward")]
+        public InputActionProperty verticalUpAction;
+
+        [Tooltip("Assign an Input Action that fires when the Y button is pressed to move downward")]
+        public InputActionProperty verticalDownAction;
+
+        // Head (Main Camera) will be assigned
+        private Transform headTransform;
+
+        // STYLY XR Rig root will be assigned
+        private Transform moveTarget;
+
+        [Tooltip("Move speed (m/s)")]
+        public float moveSpeed = 2.0f;
+
+        [Tooltip("Ignore Y component and move along the horizontal plane")]
+        private bool flattenToGroundPlane = true;
+
+        [Header("Snap Turn")]
+        [Tooltip("Snap turn angle per step (degrees)")]
+        public float snapTurnDegrees = 45f;
+
+        [Tooltip("Snap turn input threshold (right: +threshold / left: -threshold)")]
+        [Range(0.1f, 0.95f)]
+        private float snapTurnDeadzone = 0.5f;
+
+        [Tooltip("Minimum interval between consecutive snap turns in the same direction (seconds)")]
+        private float snapTurnDebounce = 0.25f;
+
+        // Internal state
+        float _prevSnapValue = 0f;
+        float _lastSnapTime = -999f;
+
+        private const float ButtonPressedThreshold = 0.5f;
+
+
+        void Start()
+        {
+            // Use Main Camera if not explicitly specified
+            if (headTransform == null && Camera.main != null)
+                headTransform = Camera.main.transform;
+            
+            // Remove redundant assignment as it's already done in Awake
+            // Only find and assign moveTarget with proper null checking
+            var stylyXrRig = FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
+            if (stylyXrRig != null)
+            {
+                moveTarget = stylyXrRig.transform;
+            }
+            else
+            {
+                Debug.LogError("VrStickController: No StylyXrRig found in the scene. Please ensure STYLY XR Rig is present.");
+            }
+        }
+
+        void OnEnable()
+        {
+            // Enable InputActions (generally safe even with Input Action Manager)
+            if (moveAction.action != null) moveAction.action.Enable();
+            if (snapTurnAction.action != null) snapTurnAction.action.Enable();
+            if (verticalUpAction.action != null) verticalUpAction.action.Enable();
+            if (verticalDownAction.action != null) verticalDownAction.action.Enable();
+        }
+
+        void OnDisable()
+        {
+            if (moveAction.action != null) moveAction.action.Disable();
+            if (snapTurnAction.action != null) snapTurnAction.action.Disable();
+            if (verticalUpAction.action != null) verticalUpAction.action.Disable();
+            if (verticalDownAction.action != null) verticalDownAction.action.Disable();
+        }
+
+        void Update()
+        {
+            HandleMove();
+            HandleVerticalMove();
+            HandleSnapTurn();
+        }
+
+        void HandleMove()
+        {
+            if (moveAction.action == null) return;
+
+            if (moveTarget == null)
+            {
+                Debug.LogError(MoveTargetNotSetError);
+                return;
+            }
+
+            Vector2 move = Vector2.zero;
+            try
+            {
+                move = moveAction.action.ReadValue<Vector2>();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.LogWarning($"VrStickController: Failed to read move input as Vector2: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"VrStickController: Unexpected error reading move input: {ex.Message}");
+            }
+
+            if (move.sqrMagnitude < 0.0001f) return;
+
+            // Forward and right vectors based on head (camera)
+            Vector3 forward = headTransform ? headTransform.forward : transform.forward;
+            Vector3 right = headTransform ? headTransform.right : transform.right;
+
+            if (flattenToGroundPlane)
+            {
+                forward = Vector3.ProjectOnPlane(forward, Vector3.up).normalized;
+                right = Vector3.ProjectOnPlane(right, Vector3.up).normalized;
+            }
+            else
+            {
+                forward.Normalize();
+                right.Normalize();
+            }
+
+            Vector3 worldMove = forward * move.y + right * move.x;
+            moveTarget.position += worldMove * moveSpeed * Time.deltaTime;
+        }
+
+        void HandleVerticalMove()
+        {
+            bool hasUpAction = verticalUpAction.action != null;
+            bool hasDownAction = verticalDownAction.action != null;
+
+            if (!hasUpAction && !hasDownAction) return;
+
+            if (moveTarget == null)
+            {
+                Debug.LogError(MoveTargetNotSetError);
+                return;
+            }
+
+            float upValue = 0f;
+            if (hasUpAction)
+            {
+                try
+                {
+                    upValue = verticalUpAction.action.ReadValue<float>();
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Debug.LogWarning($"VrStickController: Failed to read vertical up input: {ex.Message}");
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"VrStickController: Unexpected error reading vertical up input: {ex.Message}");
+                }
+            }
+
+            float downValue = 0f;
+            if (hasDownAction)
+            {
+                try
+                {
+                    downValue = verticalDownAction.action.ReadValue<float>();
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Debug.LogWarning($"VrStickController: Failed to read vertical down input: {ex.Message}");
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"VrStickController: Unexpected error reading vertical down input: {ex.Message}");
+                }
+            }
+
+            bool upPressed = hasUpAction && upValue > ButtonPressedThreshold;
+            bool downPressed = hasDownAction && downValue > ButtonPressedThreshold;
+
+            if (!upPressed && !downPressed) return;
+
+            Vector3 verticalDirection = Vector3.zero;
+            if (upPressed)
+            {
+                verticalDirection += Vector3.up;
+            }
+
+            if (downPressed)
+            {
+                verticalDirection += Vector3.down;
+            }
+
+            if (verticalDirection.sqrMagnitude < 0.0001f) return;
+
+            verticalDirection.Normalize();
+            moveTarget.position += verticalDirection * moveSpeed * Time.deltaTime;
+        }
+
+        void HandleSnapTurn()
+        {
+            if (snapTurnAction.action == null) return;
+
+            if (moveTarget == null)
+            {
+                Debug.LogError(MoveTargetNotSetError);
+                return;
+            }
+
+            float raw = 0f;
+            try
+            {
+                // XRI Snap Turn is often mapped to float or Vector2.x
+                // InputAction itself has no valueType, so check from bound control
+                var action = snapTurnAction.action;
+                InputControl control = action.activeControl ?? (action.controls.Count > 0 ? action.controls[0] : null);
+                Type ctrlType = control != null ? control.valueType : null;
+
+                if (ctrlType == typeof(Vector2))
+                {
+                    raw = action.ReadValue<Vector2>().x;
+                }
+                else
+                {
+                    // Default is float (Axis)
+                    raw = action.ReadValue<float>();
+                }
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.LogWarning($"VrStickController: Failed to read snap turn input: {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"VrStickController: Unexpected error reading snap turn input: {ex.Message}");
+            }
+
+            // Fire only on edge crossing the deadzone threshold + debounce
+            float now = Time.time;
+            bool risingRight = (_prevSnapValue <= snapTurnDeadzone) && (raw > snapTurnDeadzone);
+            bool fallingLeft = (_prevSnapValue >= -snapTurnDeadzone) && (raw < -snapTurnDeadzone);
+
+            if ((risingRight || fallingLeft) && (now - _lastSnapTime >= snapTurnDebounce))
+            {
+                float dir = risingRight ? +1f : -1f;
+                // Rotate horizontally (Y axis in world space)
+                moveTarget.Rotate(0f, snapTurnDegrees * dir, 0f, Space.World);
+                _lastSnapTime = now;
+            }
+
+            _prevSnapValue = raw;
+        }
+
+#if UNITY_EDITOR
+        void OnValidate()
+        {
+            if (headTransform == null && Camera.main != null)
+                headTransform = Camera.main.transform;
+
+            if (moveTarget == null)
+            {
+                Debug.LogWarning(MoveTargetNotSetError);
+            }
+
+            moveSpeed = Mathf.Max(0f, moveSpeed);
+            snapTurnDegrees = Mathf.Clamp(snapTurnDegrees, 1f, 180f);
+            snapTurnDebounce = Mathf.Clamp(snapTurnDebounce, 0f, 2f);
+        }
+#endif
+    }
+}

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs.meta
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/VrStickController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b7de3e7974a54b6eaa9f0b6ee1c46c6

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Just click target SDK on the menu. The SDK will be downloaded and installed. The
 - Unity Editor development support
   - Camera height is set to 1.3m only on Unity Editor
   - Camera height will be automatically set based on actual devices
+  - WASD movement in the editor mode.
+  - Stick control with VR controllers.
   - XRI interaction works on Editor mode with a mouse without XR Simulator. (Currently supported only on visionOS target)
 - AR Managers are included (disabled on start)
   - XR Interaction Manager


### PR DESCRIPTION
## Summary
- Add a `Move Physical Transform` inspector toggle to `EditorPlayerController` and `VrStickController`.
- Default the toggle to ON so editor keyboard/mouse movement and VR stick locomotion move the camera physical transform path by default.
- Keep the existing virtual XR Rig movement behavior available when the toggle is OFF.

## Details
- Resolves the Main Camera parent as the physical target, falling back to the camera transform when needed.
- Applies movement deltas in parent-local space for physical movement.
- Applies editor look/snap turn and VR snap turn through the physical target rotation when enabled.
- Avoids a direct STYLY-NetSync dependency; NetSync observes the changed camera hierarchy as Physical Position/Rotation.

## Validation
- Manual Unity compile test was completed by the requester.
- Checked the changed controller scripts for prohibited `?.` / `??` usage.