### PR TITLE
Allow configuring camera clear flags when switching from passthrough to VR

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -32,17 +32,20 @@ namespace Styly.XRRig
         private bool isTransitioning;
         private bool hasAppliedMode;
         private Coroutine transitionRoutine;
+        private CameraClearFlags _vrClearFlags = CameraClearFlags.Skybox;
 
         // --- Public API ---
         private bool passthroughMode;
         internal bool PassthroughMode => passthroughMode;
 
-        internal void SwitchToVR(float duration = 1)
+        internal void SwitchToVR(float duration = 1, CameraClearFlags clearFlags = CameraClearFlags.Skybox)
         {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
             
             if (IsRedundant(XRMode.VR)) { return; }
+
+            _vrClearFlags = clearFlags;
 
             passthroughMode = false;
             targetMode = XRMode.VR;
@@ -215,7 +218,9 @@ namespace Styly.XRRig
 
                 if (mode == XRMode.VR)
                 {
-                    cam.clearFlags = CameraClearFlags.Skybox;
+                    cam.clearFlags = _vrClearFlags;
+                    var bg = cam.backgroundColor; bg.a = 1.0f;
+                    cam.backgroundColor = bg;
                 }
                 else // MR
                 {

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -13,9 +13,9 @@ namespace Styly.XRRig
 
         public bool PassthroughMode => passthroughManager != null ? passthroughManager.PassthroughMode : passthroughMode;
 
-        public void SwitchToVR(float duration = 1)
+        public void SwitchToVR(float duration = 1, CameraClearFlags clearFlags = CameraClearFlags.Skybox)
         {
-            if (passthroughManager != null) { passthroughManager.SwitchToVR(duration); }
+            if (passthroughManager != null) { passthroughManager.SwitchToVR(duration, clearFlags); }
             if (smartphoneArCameraManager != null) { smartphoneArCameraManager.ConfigureOcclusionSettings(SmartphoneARCameraManager.OcclusionSettings.AutomaticForVR); }
         }
 


### PR DESCRIPTION
## Overview
A content team requested the ability to use a black background (`Solid Color`) after switching from passthrough (MR) mode to VR mode.
To support this, Clear Flags can now be specified in `StylyXrRig.SwitchToVR`.