### PR TITLE
Add pre-reveal callback for XR mode switches

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
@@ -39,6 +40,11 @@ namespace Styly.XRRig
 
         internal void SwitchToVR(float duration = 1)
         {
+            SwitchToVR(duration, null);
+        }
+
+        internal void SwitchToVR(float duration, Action onBeforeReveal)
+        {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
             
@@ -50,7 +56,7 @@ namespace Styly.XRRig
             CancelInvoke(nameof(DisablePassthroughAPI));
             CancelInvoke(nameof(DisableARCamera));
 
-            StartTransition(XRMode.VR, duration);
+            StartTransition(XRMode.VR, duration, onBeforeReveal);
 
             if (duration <= 0f)
             {
@@ -66,6 +72,11 @@ namespace Styly.XRRig
 
         internal void SwitchToMR(float duration = 1)
         {
+            SwitchToMR(duration, null);
+        }
+
+        internal void SwitchToMR(float duration, Action onBeforeReveal)
+        {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
             
@@ -79,7 +90,7 @@ namespace Styly.XRRig
 
             EnableARCamera();
             EnablePassthroughAPI();
-            StartTransition(XRMode.MR, duration);
+            StartTransition(XRMode.MR, duration, onBeforeReveal);
         }
 
         private void EnableARCamera()
@@ -153,7 +164,7 @@ namespace Styly.XRRig
         }
 
         // --- Core ---
-        private void StartTransition(XRMode next, float duration = 1)
+        private void StartTransition(XRMode next, float duration, Action onBeforeReveal)
         {
             transitionDuration = duration;
             if (!isActiveAndEnabled) return;
@@ -170,6 +181,7 @@ namespace Styly.XRRig
             if (transitionDuration <= 0f)
             {
                 ApplyMode(next);
+                InvokeOnBeforeReveal(onBeforeReveal);
                 currentMode = next;
                 isTransitioning = false;
                 transitionRoutine = null;
@@ -178,18 +190,31 @@ namespace Styly.XRRig
             }
 
             isTransitioning = true;
-            transitionRoutine = StartCoroutine(DoTransition(next)); // Fade → Switch → Fade
+            transitionRoutine = StartCoroutine(DoTransition(next, onBeforeReveal)); // Fade → Switch → Fade
         }
 
-        private IEnumerator DoTransition(XRMode next)
+        private IEnumerator DoTransition(XRMode next, Action onBeforeReveal)
         {
             float half = transitionDuration * 0.5f;
             yield return Fade(0f, 1f, half);
             ApplyMode(next);
+            InvokeOnBeforeReveal(onBeforeReveal);
             yield return Fade(1f, 0f, half);
             SetFadeAlpha(0f);
             isTransitioning = false;
             transitionRoutine = null;
+        }
+
+        private void InvokeOnBeforeReveal(Action onBeforeReveal)
+        {
+            try
+            {
+                onBeforeReveal?.Invoke();
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
         }
 
         private IEnumerator Fade(float from, float to, float duration)

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/StylyXrRig.cs
@@ -15,13 +15,23 @@ namespace Styly.XRRig
 
         public void SwitchToVR(float duration = 1)
         {
-            if (passthroughManager != null) { passthroughManager.SwitchToVR(duration); }
+            SwitchToVR(duration, null);
+        }
+
+        public void SwitchToVR(float duration, System.Action onBeforeReveal)
+        {
+            if (passthroughManager != null) { passthroughManager.SwitchToVR(duration, onBeforeReveal); }
             if (smartphoneArCameraManager != null) { smartphoneArCameraManager.ConfigureOcclusionSettings(SmartphoneARCameraManager.OcclusionSettings.AutomaticForVR); }
         }
 
         public void SwitchToMR(float duration = 1)
         {
-            if (passthroughManager != null) { passthroughManager.SwitchToMR(duration); }
+            SwitchToMR(duration, null);
+        }
+
+        public void SwitchToMR(float duration, System.Action onBeforeReveal)
+        {
+            if (passthroughManager != null) { passthroughManager.SwitchToMR(duration, onBeforeReveal); }
             if (smartphoneArCameraManager != null) { smartphoneArCameraManager.ConfigureOcclusionSettings(SmartphoneARCameraManager.OcclusionSettings.AutomaticForMR); }
         }
 


### PR DESCRIPTION
  ## Summary

  Adds overloads for `SwitchToVR` and `SwitchToMR` that accept an `Action onBeforeReveal` callback.

  The callback is invoked after the XR mode has been applied and before the fade overlay is revealed, allowing
  callers to update camera/rendering state while the transition is still hidden.

  ## Changes

  - Added `SwitchToVR(float duration, Action onBeforeReveal)`
  - Added `SwitchToMR(float duration, Action onBeforeReveal)`
  - Kept existing `SwitchToVR(float duration = 1)` and `SwitchToMR(float duration = 1)` APIs compatible
  - Executes the callback for both instant and faded transitions
  - Logs callback exceptions with `Debug.LogException`

  ## Verification

  - Confirmed with a sample that camera clear flags can be changed before reveal during VR/MR transitions
  - Unity compile passed with 0 errors / 0 warnings