### PR TITLE
Add release workflow (version bump + release draft)

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -74,7 +74,7 @@ jobs:
           echo "This workflow will update the package version from $CURRENT_VERSION to $VERSION"
 
           # Save current version to environment variable for use in Summary
-          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          printf 'CURRENT_VERSION=%s\n' "$CURRENT_VERSION" >> "$GITHUB_ENV"
 
       - name: Update Unity package.json version
         run: |
@@ -96,10 +96,12 @@ jobs:
         run: |
           git add Packages/com.styly.styly-xr-rig/package.json
 
-          # Check if there are changes to commit
+          # Fail fast if there is nothing to commit: continuing would push/merge
+          # and try to tag a release without an actual version bump (and the
+          # tag may already exist), so stop the workflow here instead.
           if git diff --staged --quiet; then
-            echo "⚠️ Warning: No changes to commit. Version may already be set to $VERSION"
-            exit 0
+            echo "❌ Error: No changes to commit. Version is already set to $VERSION"
+            exit 1
           fi
 
           # Commit changes
@@ -117,8 +119,9 @@ jobs:
           # Fetch all remote branches to ensure latest refs
           git fetch origin
 
-          # Checkout main branch
-          git checkout main
+          # Create/reset a local main that exactly matches origin/main so the
+          # fast-forward merge is deterministic regardless of any stale local main
+          git checkout -B main origin/main
 
           # Fast-forward merge origin/develop into main
           git merge --ff-only origin/develop

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,210 @@
+name: '_Release workflow'
+
+on:
+  workflow_dispatch:
+    inputs:
+      info:
+        description: |
+          This workflow will set the version for the Unity package, commit the version change to develop, merge develop into main and create a release draft.
+        required: false
+        type: boolean
+      version:
+        description: 'Version number (e.g., 0.4.21).'
+        required: true
+        type: string
+
+# Allow the default GITHUB_TOKEN to push commits/branches and create releases
+permissions:
+  contents: write
+
+jobs:
+  set-version-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0  # Full history for merge operations
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version format
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          VERSION="$INPUT_VERSION"
+          # Strip leading 'v' or 'V' prefix if present
+          VERSION="${VERSION#[vV]}"
+          # Check semantic versioning format (including pre-release versions)
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "❌ Error: Invalid version format: $VERSION"
+            echo "Version must follow semantic versioning (e.g., 1.0.0 or 1.0.0-beta.1)"
+            exit 1
+          fi
+          echo "✅ Version format is valid: $VERSION"
+          # Export normalized version for subsequent steps
+          printf 'VERSION=%s\n' "$VERSION" >> "$GITHUB_ENV"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if develop branch is up to date
+        run: |
+          git fetch origin develop
+          LOCAL_COMMIT=$(git rev-parse HEAD)
+          REMOTE_COMMIT=$(git rev-parse origin/develop)
+
+          if [ "$LOCAL_COMMIT" != "$REMOTE_COMMIT" ]; then
+            echo "❌ Error: develop branch is not up to date with origin/develop"
+            echo "Please pull the latest changes from origin/develop before running this workflow"
+            exit 1
+          fi
+          echo "✅ develop branch is up to date"
+
+      - name: Display current version
+        run: |
+          PACKAGE_FILE="Packages/com.styly.styly-xr-rig/package.json"
+          CURRENT_VERSION=$(jq -r '.version' "$PACKAGE_FILE")
+          echo "📦 Current version: $CURRENT_VERSION"
+          echo "🎯 Target version: $VERSION"
+          echo ""
+          echo "This workflow will update the package version from $CURRENT_VERSION to $VERSION"
+
+          # Save current version to environment variable for use in Summary
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+
+      - name: Update Unity package.json version
+        run: |
+          PACKAGE_FILE="Packages/com.styly.styly-xr-rig/package.json"
+
+          if [ ! -f "$PACKAGE_FILE" ]; then
+            echo "❌ Error: Unity package.json not found at $PACKAGE_FILE"
+            exit 1
+          fi
+
+          # Update version using jq (precise JSON manipulation)
+          jq --arg ver "$VERSION" '.version = $ver' "$PACKAGE_FILE" > tmp.json && mv tmp.json "$PACKAGE_FILE"
+
+          echo "✅ Updated Unity package.json version to $VERSION"
+          echo "Updated content:"
+          cat "$PACKAGE_FILE"
+
+      - name: Commit version changes
+        run: |
+          git add Packages/com.styly.styly-xr-rig/package.json
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "⚠️ Warning: No changes to commit. Version may already be set to $VERSION"
+            exit 0
+          fi
+
+          # Commit changes
+          git commit -m "Bump version from $CURRENT_VERSION to $VERSION"
+
+          echo "✅ Committed version changes"
+
+      - name: Push to develop branch
+        run: |
+          git push origin develop
+          echo "✅ Pushed changes to develop branch"
+
+      - name: Merge develop into main
+        run: |
+          # Fetch all remote branches to ensure latest refs
+          git fetch origin
+
+          # Checkout main branch
+          git checkout main
+
+          # Fast-forward merge origin/develop into main
+          git merge --ff-only origin/develop
+
+          echo "✅ Successfully fast-forward merged origin/develop into main"
+
+      - name: Push main branch
+        run: |
+          git push origin main
+          echo "✅ Pushed changes to main branch"
+
+      - name: Create Release Draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="v$VERSION"
+
+          echo "Creating release draft for $TAG_NAME..."
+
+          # Create release draft using GitHub CLI with auto-generated notes
+          gh release create "$TAG_NAME" \
+            --draft \
+            --target main \
+            --title "$TAG_NAME" \
+            --generate-notes
+
+          echo "✅ Release draft created: $TAG_NAME"
+          echo "📝 Please edit the release notes at: https://github.com/${{ github.repository }}/releases"
+
+      - name: Summary
+        if: always()
+        run: |
+          TAG_NAME="v$VERSION"
+
+          # Write to GitHub Step Summary
+          {
+            echo "# 📦 Version Release Workflow Summary"
+            echo ""
+
+            if [ "${{ job.status }}" == "success" ]; then
+              echo "## ✅ Status: Success"
+              echo ""
+              echo "### 🔄 Version Change"
+              echo ""
+              echo "| From | To |"
+              echo "|------|-----|"
+              echo "| \`${CURRENT_VERSION}\` | \`$VERSION\` |"
+              echo ""
+              echo "### 🎯 Completed Actions"
+              echo ""
+              echo "| Step | Status | Description |"
+              echo "|------|--------|-------------|"
+              echo "| Version Update | ✅ | Updated Unity package.json to \`$VERSION\` |"
+              echo "| Git Commit | ✅ | Committed changes to develop branch |"
+              echo "| Branch Merge | ✅ | Fast-forward merged develop → main |"
+              echo "| Release Draft | ✅ | Created draft release with tag \`$TAG_NAME\` |"
+              echo ""
+              echo "### 📦 Updated Files"
+              echo ""
+              echo "- \`Packages/com.styly.styly-xr-rig/package.json\`"
+              echo ""
+              echo "### 🚀 Next Steps"
+              echo ""
+              echo "**Review Release Draft**"
+              echo "   - [Edit Release Draft](https://github.com/${{ github.repository }}/releases)"
+            else
+              echo "## ❌ Status: Failed"
+              echo ""
+              echo "### 🔍 Troubleshooting"
+              echo ""
+              echo "Please check the workflow logs above for detailed error messages."
+              echo ""
+              echo "#### Common Issues:"
+              echo "- **Version format invalid**: Ensure version follows semantic versioning (x.x.x)"
+              echo "- **Branch not up to date**: Pull latest changes from origin/develop"
+              echo "- **Merge conflict**: main branch has diverged from develop (non fast-forward)"
+              echo "- **Permission denied**: Check GitHub token permissions"
+              echo ""
+              echo "### 🔧 Recovery Steps"
+              echo ""
+              echo "1. Fix the issue based on error messages"
+              echo "2. Ensure develop branch is up to date"
+              echo "3. Re-run this workflow"
+            fi
+
+            echo ""
+            echo "---"
+            echo "*Generated at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')*"
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a manually-triggered (`workflow_dispatch`) release workflow at `.github/workflows/release-workflow.yml`, adapted from the [STYLY-NetSync release workflow](https://github.com/styly-dev/STYLY-NetSync/blob/develop/.github/workflows/release-workflow.yml) for this single Unity UPM package repo.

## What it does

Given a `version` input, the workflow:

1. Checks out `develop` and validates the version is semver (strips a leading `v`/`V`).
2. Verifies local `develop` matches `origin/develop`.
3. Bumps the version in `Packages/com.styly.styly-xr-rig/package.json` via `jq`.
4. Commits as `Bump version from X to Y` (matching the existing commit style) and pushes `develop`.
5. Fast-forward merges `develop` → `main` and pushes `main`.
6. Creates a **draft** GitHub release tagged `vX.Y.Z` targeting `main`, with auto-generated notes.
7. Writes a summary table to the Actions step summary.

## Differences vs. the NetSync reference

This repo is a single Unity package, so the inapplicable steps were dropped:

- No Python `pyproject.toml` update.
- No `version.txt` update (this package has none).
- No `.md` version rewriting (no pinned `com.styly.styly-xr-rig@x.y.z` references).
- Package path is repo-root `Packages/...`.
- Release notes use `--generate-notes`.
- Added `permissions: contents: write`; the version input is passed via an env var (no direct shell interpolation).

## Before relying on it

- **Branch protection**: the workflow pushes directly to `develop` and `main`. If either is protected against direct pushes, allow the Actions bot or use a PAT.
- The `--ff-only` merge requires `main` to be a strict ancestor of `develop` (fails safely otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)