### PR TITLE
Disable editor controller when XR interaction simulator is active

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.XR.Interaction.Toolkit.Inputs.Simulation;
 
 namespace Styly.XRRig
 {
@@ -36,8 +37,22 @@ namespace Styly.XRRig
         private float rotationY = 0f;
         private float lastSnapTime = -999f;
 
+        void OnEnable()
+        {
+            if (ShouldDisableForXRInteractionSimulator())
+            {
+                enabled = false;
+            }
+        }
+
         void Start()
         {
+            if (ShouldDisableForXRInteractionSimulator())
+            {
+                enabled = false;
+                return;
+            }
+
             // Set control target (use self if target is null)
             controlTarget = target != null ? target : transform;
 
@@ -72,6 +87,17 @@ namespace Styly.XRRig
             HandleMovement();
             HandleRotation();
             HandleSnapTurn();
+        }
+
+        private static bool ShouldDisableForXRInteractionSimulator()
+        {
+            if (XRInteractionSimulator.instance != null && XRInteractionSimulator.instance.isActiveAndEnabled)
+            {
+                return true;
+            }
+
+            var simulator = Object.FindAnyObjectByType<XRInteractionSimulator>(FindObjectsInactive.Exclude);
+            return simulator != null && simulator.isActiveAndEnabled;
         }
 
         /// <summary>

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/EditorPlayerController.cs
@@ -50,7 +50,6 @@ namespace Styly.XRRig
             if (ShouldDisableForXRInteractionSimulator())
             {
                 enabled = false;
-                return;
             }
 
             // Set control target (use self if target is null)


### PR DESCRIPTION
## Summary

This PR disables the STYLY XR Rig `EditorPlayerController` when an active XR Interaction Simulator exists in the scene/runtime.

When both are enabled, editor keyboard/mouse movement from `EditorPlayerController` can conflict with XR Interaction Simulator input, causing duplicate or competing player/camera movement.

## Changes

- Detects active `XRInteractionSimulator` instances from `EditorPlayerController`
- Disables `EditorPlayerController` when an active simulator is found
- Runs the check in both `OnEnable` and `Start` to cover scene-placed and runtime-created simulators
- Does not depend on the `Use XR Interaction Simulator in scenes` project setting