### PR TITLE
Fix PICO AR camera background initialization

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -154,6 +154,11 @@ namespace Styly.XRRig
             {
                 mainCameraOfStylyXrRig.gameObject.AddComponent<SmartphoneARCameraManager>();
             }
+            // ARCameraBackground accesses ARCameraManager during OnEnable, so it must exist first.
+            if (mainCameraOfStylyXrRig.gameObject.GetComponent<ARCameraManager>() == null)
+            {
+                mainCameraOfStylyXrRig.gameObject.AddComponent<ARCameraManager>();
+            }
             // Add AR Camera Background if not already present
             if (mainCameraOfStylyXrRig.gameObject.GetComponent<ARCameraBackground>() == null)
             {


### PR DESCRIPTION
## Summary
- Add `ARCameraManager` before `ARCameraBackground` during passthrough camera setup.
- Prevent `ARCameraBackground.OnEnable()` from running before its required camera manager exists on PICO.

## Root cause
`SmartphoneARCameraManager` creates `ARCameraManager` in its `Start()`, but `ARCameraBackground` is enabled immediately when it is added.

## Validation
- Confirmed the AR Foundation 6.3.0 API reference is already imported by `PassthroughManager`.
- `git diff --check` passed.
- Unity CLI Loop compilation was unavailable because this checkout does not include `UserSettings/UnityMcpSettings.json`.

Fixes #194