### PR TITLE
Fix passthrough startup initialization

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -32,6 +32,7 @@ namespace Styly.XRRig
         private XRMode targetMode = XRMode.VR;
         private bool isTransitioning;
         private bool hasAppliedMode;
+        private bool isInitialized;
         private Coroutine transitionRoutine;
 
         // --- Public API ---
@@ -47,6 +48,7 @@ namespace Styly.XRRig
         {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
+            if (!EnsureInitialized()) { return; }
             
             if (IsRedundant(XRMode.VR)) { return; }
 
@@ -79,6 +81,7 @@ namespace Styly.XRRig
         {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
+            if (!EnsureInitialized()) { return; }
             
             if (IsRedundant(XRMode.MR)) { return; }
 
@@ -135,9 +138,7 @@ namespace Styly.XRRig
 
         void Start()
         {
-            if (!ResolveMainCamera()) return;
-            BuildTargetsAndOverlays();
-            SetUpCameraForPassthrough();
+            EnsureInitialized();
         }
 
         public void SetUpCameraForPassthrough()
@@ -275,12 +276,32 @@ namespace Styly.XRRig
         }
 
         // --- Setup ---
+        private bool EnsureInitialized()
+        {
+            if (isInitialized) { return true; }
+            if (!ResolveMainCamera()) { return false; }
+
+            BuildTargetsAndOverlays();
+            SetUpCameraForPassthrough();
+            isInitialized = true;
+            return true;
+        }
+
         private bool ResolveMainCamera()
         {
             // Find Main Camera of STYLY-XR-Rig
             var STYLYXRRig = GameObject.FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
+            if (STYLYXRRig == null)
+            {
+                Debug.LogError("StylyXrRig not found in the scene.");
+                return false;
+            }
+
             mainCameraOfStylyXrRig = STYLYXRRig.transform.GetComponentsInChildren<Camera>().FirstOrDefault(camera => camera.CompareTag("MainCamera"));
-            return true;
+            if (mainCameraOfStylyXrRig != null) { return true; }
+
+            Debug.LogError("MainCamera not found in StylyXrRig.");
+            return false;
         }
 
         private void BuildTargetsAndOverlays()

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/PassthroughManager.cs
@@ -32,7 +32,6 @@ namespace Styly.XRRig
         private XRMode targetMode = XRMode.VR;
         private bool isTransitioning;
         private bool hasAppliedMode;
-        private bool isInitialized;
         private Coroutine transitionRoutine;
 
         // --- Public API ---
@@ -48,7 +47,6 @@ namespace Styly.XRRig
         {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
-            if (!EnsureInitialized()) { return; }
             
             if (IsRedundant(XRMode.VR)) { return; }
 
@@ -81,7 +79,6 @@ namespace Styly.XRRig
         {
             // Skip on Vision OS
             if (Utils.IsVisionOS()) { return; }
-            if (!EnsureInitialized()) { return; }
             
             if (IsRedundant(XRMode.MR)) { return; }
 
@@ -136,9 +133,11 @@ namespace Styly.XRRig
             }
         }
 
-        void Start()
+        void Awake()
         {
-            EnsureInitialized();
+            if (!ResolveMainCamera()) return;
+            BuildTargetsAndOverlays();
+            SetUpCameraForPassthrough();
         }
 
         public void SetUpCameraForPassthrough()
@@ -276,32 +275,12 @@ namespace Styly.XRRig
         }
 
         // --- Setup ---
-        private bool EnsureInitialized()
-        {
-            if (isInitialized) { return true; }
-            if (!ResolveMainCamera()) { return false; }
-
-            BuildTargetsAndOverlays();
-            SetUpCameraForPassthrough();
-            isInitialized = true;
-            return true;
-        }
-
         private bool ResolveMainCamera()
         {
             // Find Main Camera of STYLY-XR-Rig
             var STYLYXRRig = GameObject.FindFirstObjectByType<Styly.XRRig.StylyXrRig>();
-            if (STYLYXRRig == null)
-            {
-                Debug.LogError("StylyXrRig not found in the scene.");
-                return false;
-            }
-
             mainCameraOfStylyXrRig = STYLYXRRig.transform.GetComponentsInChildren<Camera>().FirstOrDefault(camera => camera.CompareTag("MainCamera"));
-            if (mainCameraOfStylyXrRig != null) { return true; }
-
-            Debug.LogError("MainCamera not found in StylyXrRig.");
-            return false;
+            return true;
         }
 
         private void BuildTargetsAndOverlays()

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
@@ -107,8 +107,6 @@ namespace Styly.XRRig
         public void ConfigureOcclusionSettings(OcclusionSettings settings)
         {
 #if !UNITY_EDITOR
-            if (!EnsureOcclusionManager()) { return; }
-
             switch (settings)
             {
                 case OcclusionSettings.Disabled:
@@ -153,18 +151,6 @@ namespace Styly.XRRig
                     break;
             }
 #endif
-        }
-
-        private bool EnsureOcclusionManager()
-        {
-            if (arOcclusionManager != null) { return true; }
-            if (TryGetComponent(out arOcclusionManager)) { return true; }
-
-            AddOcclusionComponents();
-            if (arOcclusionManager != null) { return true; }
-
-            Debug.LogWarning("AROcclusionManager component not found on the Main Camera.");
-            return false;
         }
     }
 }

--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
@@ -107,6 +107,8 @@ namespace Styly.XRRig
         public void ConfigureOcclusionSettings(OcclusionSettings settings)
         {
 #if !UNITY_EDITOR
+            if (!EnsureOcclusionManager()) { return; }
+
             switch (settings)
             {
                 case OcclusionSettings.Disabled:
@@ -151,6 +153,18 @@ namespace Styly.XRRig
                     break;
             }
 #endif
+        }
+
+        private bool EnsureOcclusionManager()
+        {
+            if (arOcclusionManager != null) { return true; }
+            if (TryGetComponent(out arOcclusionManager)) { return true; }
+
+            AddOcclusionComponents();
+            if (arOcclusionManager != null) { return true; }
+
+            Debug.LogWarning("AROcclusionManager component not found on the Main Camera.");
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

Move the existing `PassthroughManager` setup from `Start()` to `Awake()`.

## Root cause

`StylyXrRig.Start()` can run before `PassthroughManager.Start()`. In that order, the initial `SwitchToVR(0)` / `SwitchToMR(0)` reaches `BuildTargetsAndOverlays()` while `mainCameraOfStylyXrRig` is still null.

Unity completes every active component's `Awake()` before invoking any `Start()`. Initializing the manager in `Awake()` therefore makes the camera reference, fade overlays, and passthrough camera setup available before `StylyXrRig.Start()` switches the initial mode.

## Validation

- Unity recompile: 0 errors.
- PICO 4 Ultra Enterprise: installed the development APK and launched `UnityPlayerActivity`; the Issue #175 `PassthroughManager.BuildTargetsAndOverlays()` NullReferenceException was not reproduced.

A separate startup `NullReferenceException` in `SmartphoneARCameraManager.ConfigureOcclusionSettings()` was observed on the device. It is outside Issue #175 and intentionally not changed by this PR.

Closes #175