### PR TITLE
Fix occlusion manager initialization race on startup

### DIFF
--- a/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
+++ b/Packages/com.styly.styly-xr-rig/Runtime/Scripts/SmartphoneARCameraManager.cs
@@ -107,6 +107,8 @@ namespace Styly.XRRig
         public void ConfigureOcclusionSettings(OcclusionSettings settings)
         {
 #if !UNITY_EDITOR
+            if (arOcclusionManager == null) { AddOcclusionComponents(); }
+
             switch (settings)
             {
                 case OcclusionSettings.Disabled:


### PR DESCRIPTION
## Summary

- Initialize AR occlusion components on demand before applying occlusion settings.
- Prevent the startup `NullReferenceException` in `SmartphoneARCameraManager.ConfigureOcclusionSettings` on PICO 4 Ultra.

## Root cause

`StylyXrRig.Start()` and `SmartphoneARCameraManager.Start()` have no guaranteed execution order. When `StylyXrRig.Start()` called `ConfigureOcclusionSettings()` first, `arOcclusionManager` had not yet been initialized.

## Change

If `arOcclusionManager` is null when configuring occlusion, reuse the existing `AddOcclusionComponents()` initialization path before applying the settings.